### PR TITLE
Added capture the flag event

### DIFF
--- a/static/scripts/localizable.js
+++ b/static/scripts/localizable.js
@@ -29,6 +29,11 @@ let _localizable = {
 		"en": "disconnected",
 		"de": "getrennt"
 	},
+	"captured_flag": {
+		"ru": "захватил флаг",
+		"en": "captured the flag",
+		"de": "hat die Flag gekapert"
+	},
 	"by_injured": {
 		"ru": " был ранен ",
 		"en": " injured by ",

--- a/static/scripts/localizable.js
+++ b/static/scripts/localizable.js
@@ -32,7 +32,7 @@ let _localizable = {
 	"captured_flag": {
 		"ru": "захватил флаг",
 		"en": "captured the flag",
-		"de": "hat die Flag gekapert"
+		"de": "hat die Flagge gekapert"
 	},
 	"by_injured": {
 		"ru": " был ранен ",

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -139,7 +139,7 @@ class ConnectEvent {
 }
 
 class CaptureFlagEvent {
-	constructor(frameNum, type, unitName) {
+	constructor(frameNum, type, unitName, side) {
 		this.frameNum = frameNum;
 		this.timecode = dateToTimeString(new Date(frameNum * frameCaptureDelay));
 		this.type = type;
@@ -149,7 +149,26 @@ class CaptureFlagEvent {
 		// Create list element for this event (for later use)
 		var span = document.createElement("span");
 		span.className = "medium";
-		localizable(span, "captured_flag", "", `${this.unitName} `);
+
+		if (this.side == "") {
+			span.textContent = msg;
+		} else {
+			localizable(span, "captured_flag", "", `${this.unitName} `);
+			switch (true) {
+				case (side == "EAST"):
+					span.className = "opfor";
+					break;
+				case (side == "WEST"):
+					span.className = "blufor";
+					break;
+				case (side == "IND"):
+					span.className = "ind";
+					break;
+				case (side == "CIV"):
+					span.className = "civ";
+					break;
+			}
+		}
 
 		var detailsDiv = document.createElement("div");
 		detailsDiv.className = "eventDetails";
@@ -191,6 +210,9 @@ class endMissionEvent {
 					break;
 				case (side == "IND"):
 					span.className = "ind";
+					break;
+				case (side == "CIV"):
+					span.className = "civ";
 					break;
 			}
 		}

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -171,7 +171,7 @@ class CaptureFlagEvent {
 
 		const messageSpan = document.createElement("span");
 		messageSpan.className = "medium";
-		localizable(messageSpan, "captured_flag", " ", `${this.unitName} `);
+		localizable(messageSpan, "captured_flag", " ", " ");
 
 		const img = document.createElement("img");
 		img.src = "/images/markers/mil_flag/ffffff.png";

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -139,53 +139,65 @@ class ConnectEvent {
 }
 
 class CaptureFlagEvent {
-	constructor(frameNum, type, unitName, side) {
+	constructor(frameNum, type, unitName, unitSide, flagSide) {
 		this.frameNum = frameNum;
 		this.timecode = dateToTimeString(new Date(frameNum * frameCaptureDelay));
 		this.type = type;
 		this.unitName = unitName;
-		this.side = side;
+		this.unitSide = unitSide;
+		this.flagSide = flagSide;
 		this._element = null;
 
 		// Create list element for this event (for later use)
-		var unitSpan = document.createElement("span");
+		const unitSpan = document.createElement("span");
 		unitSpan.className = "medium";
 		unitSpan.textContent = `${this.unitName} `;
+		if (this.unitSide !== "") {
+			switch (true) {
+				case (this.unitSide === "EAST"):
+					unitSpan.className = "opfor";
+					break;
+				case (this.unitSide === "WEST"):
+					unitSpan.className = "blufor";
+					break;
+				case (this.unitSide === "IND"):
+					unitSpan.className = "ind";
+					break;
+				case (this.unitSide === "CIV"):
+					unitSpan.className = "civ";
+					break;
+			}
+		}
 
-		var messageSpan = document.createElement("span");
+		const messageSpan = document.createElement("span");
 		messageSpan.className = "medium";
 		localizable(messageSpan, "captured_flag", " ", `${this.unitName} `);
 
-		var img = document.createElement("img");
-		img.src = "/images/markers/mil_flag/FFFFFF.png";
+		const img = document.createElement("img");
+		img.src = "/images/markers/mil_flag/ffffff.png";
 		img.style.height = "12px";
-
-		if (this.side != "") {
+		if (this.flagSide !== "") {
 			switch (true) {
-				case (this.side == "EAST"):
-					unitSpan.className = "opfor";
+				case (this.flagSide === "EAST"):
 					img.src = "/images/markers/mil_flag/ff0000.png";
 					break;
-				case (this.side == "WEST"):
-					unitSpan.className = "blufor";
+				case (this.flagSide === "WEST"):
 					img.src = "/images/markers/mil_flag/00a8ff.png";
 					break;
-				case (this.side == "IND"):
-					unitSpan.className = "ind";
+				case (this.flagSide === "IND"):
 					img.src = "/images/markers/mil_flag/00cc00.png";
 					break;
-				case (this.side == "CIV"):
-					unitSpan.className = "civ";
+				case (this.flagSide === "CIV"):
 					img.src = "/images/markers/mil_flag/C900FF.png";
 					break;
 			}
 		}
 
-		var detailsDiv = document.createElement("div");
+		const detailsDiv = document.createElement("div");
 		detailsDiv.className = "eventDetails";
 		detailsDiv.textContent = this.timecode;
 
-		var li = document.createElement("li");
+		const li = document.createElement("li");
 		li.appendChild(unitSpan);
 		li.appendChild(messageSpan);
 		li.appendChild(img);

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -137,6 +137,33 @@ class ConnectEvent {
 
 	getElement() { return this._element };
 }
+
+class CaptureFlagEvent {
+	constructor(frameNum, type, unitName) {
+		this.frameNum = frameNum;
+		this.timecode = dateToTimeString(new Date(frameNum * frameCaptureDelay));
+		this.type = type;
+		this.unitName = unitName;
+		this._element = null;
+
+		// Create list element for this event (for later use)
+		var span = document.createElement("span");
+		span.className = "medium";
+		localizable(span, "captured_flag", "", `${this.unitName} `);
+
+		var detailsDiv = document.createElement("div");
+		detailsDiv.className = "eventDetails";
+		detailsDiv.textContent = this.timecode;
+
+		var li = document.createElement("li");
+		li.appendChild(span);
+		li.appendChild(detailsDiv);
+		this._element = li;
+	};
+
+	getElement() { return this._element };
+}
+
 // [4639, "endMission", ["EAST", "Offar Factory зазахвачена. Победа Сил РФ."]]
 class endMissionEvent {
 	constructor(frameNum, type, side, msg) {

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -144,28 +144,39 @@ class CaptureFlagEvent {
 		this.timecode = dateToTimeString(new Date(frameNum * frameCaptureDelay));
 		this.type = type;
 		this.unitName = unitName;
+		this.side = side;
 		this._element = null;
 
 		// Create list element for this event (for later use)
-		var span = document.createElement("span");
-		span.className = "medium";
+		var unitSpan = document.createElement("span");
+		unitSpan.className = "medium";
+		unitSpan.textContent = `${this.unitName} `;
 
-		if (this.side == "") {
-			span.textContent = msg;
-		} else {
-			localizable(span, "captured_flag", "", `${this.unitName} `);
+		var messageSpan = document.createElement("span");
+		messageSpan.className = "medium";
+		localizable(messageSpan, "captured_flag", " ", `${this.unitName} `);
+
+		var img = document.createElement("img");
+		img.src = "/images/markers/mil_flag/FFFFFF.png";
+		img.style.height = "12px";
+
+		if (this.side != "") {
 			switch (true) {
-				case (side == "EAST"):
-					span.className = "opfor";
+				case (this.side == "EAST"):
+					unitSpan.className = "opfor";
+					img.src = "/images/markers/mil_flag/ff0000.png";
 					break;
-				case (side == "WEST"):
-					span.className = "blufor";
+				case (this.side == "WEST"):
+					unitSpan.className = "blufor";
+					img.src = "/images/markers/mil_flag/00a8ff.png";
 					break;
-				case (side == "IND"):
-					span.className = "ind";
+				case (this.side == "IND"):
+					unitSpan.className = "ind";
+					img.src = "/images/markers/mil_flag/00cc00.png";
 					break;
-				case (side == "CIV"):
-					span.className = "civ";
+				case (this.side == "CIV"):
+					unitSpan.className = "civ";
+					img.src = "/images/markers/mil_flag/C900FF.png";
 					break;
 			}
 		}
@@ -175,7 +186,9 @@ class CaptureFlagEvent {
 		detailsDiv.textContent = this.timecode;
 
 		var li = document.createElement("li");
-		li.appendChild(span);
+		li.appendChild(unitSpan);
+		li.appendChild(messageSpan);
+		li.appendChild(img);
 		li.appendChild(detailsDiv);
 		this._element = li;
 	};
@@ -202,16 +215,16 @@ class endMissionEvent {
 		} else {
 			localizable(span, "win", ` ${side}. ${msg}`);
 			switch (true) {
-				case (side == "EAST"):
+				case (this.side == "EAST"):
 					span.className = "opfor";
 					break;
-				case (side == "WEST"):
+				case (this.side == "WEST"):
 					span.className = "blufor";
 					break;
-				case (side == "IND"):
+				case (this.side == "IND"):
 					span.className = "ind";
 					break;
-				case (side == "CIV"):
+				case (this.side == "CIV"):
 					span.className = "civ";
 					break;
 			}

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -691,8 +691,8 @@ function processOp (filepath) {
 				case (type == "connected" || type == "disconnected"):
 					gameEvent = new ConnectEvent(frameNum, type, eventJSON[2]);
 					break;
-				case (type == "captureFlag"):
-					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2]);
+				case (type == "capturedFlag"):
+					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1]);
 					break;
 				case (type == "endMission"):
 					gameEvent = new endMissionEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1]);

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -692,7 +692,7 @@ function processOp (filepath) {
 					gameEvent = new ConnectEvent(frameNum, type, eventJSON[2]);
 					break;
 				case (type == "capturedFlag"):
-					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1]);
+					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2]);
 					break;
 				case (type == "endMission"):
 					gameEvent = new endMissionEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1]);

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -555,7 +555,7 @@ function processOp (filepath) {
 				var unit = new Unit(startFrameNum, id, name, group, entityJSON.side, (entityJSON.isPlayer == 1), positions, entityJSON.framesFired, entityJSON.role);
 				entities.add(unit);
 
-				
+
 
 				// Show title side
 				if (arrSideSelect.indexOf(entityJSON.side) == -1) {
@@ -690,6 +690,9 @@ function processOp (filepath) {
 					break;
 				case (type == "connected" || type == "disconnected"):
 					gameEvent = new ConnectEvent(frameNum, type, eventJSON[2]);
+					break;
+				case (type == "captureFlag"):
+					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2]);
 					break;
 				case (type == "endMission"):
 					gameEvent = new endMissionEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1]);


### PR DESCRIPTION
Related to https://github.com/OCAP2/OCAP/issues/7

![image](https://user-images.githubusercontent.com/1900106/125207664-c519ca80-e28d-11eb-9a20-db8e3a63911d.png)


Parameter in order:
- unit name
- unit side
- flag side (for color, otherwise unknown side to be white)
```sqf
["ocap_handleCustomEvent", ["capturedFlag", [name _unit, str side group _unit, str side _flag]]] call CBA_fnc_serverEvent;
```