### PR TITLE
Added new "captured" event

### DIFF
--- a/static/leaflet/L.Icon.Pulse.js
+++ b/static/leaflet/L.Icon.Pulse.js
@@ -9,6 +9,7 @@
             color: 'red',
             animate: true,
             heartbeat: 1,
+            iterationCount: 'infinite'
         },
 
         initialize: function (options) {
@@ -24,7 +25,7 @@
                 'box-shadow: 0 0 6px 2px '+this.options.color,
 
                 'animation: pulsate ' + this.options.heartbeat + 's ease-out',
-                'animation-iteration-count: infinite',
+                `animation-iteration-count: ${this.options.iterationCount}`,
                 // 'animation-delay: '+ (this.options.heartbeat + .1) + 's',
                 'position:absolute',
                 'left:0',

--- a/static/scripts/localizable.js
+++ b/static/scripts/localizable.js
@@ -29,6 +29,11 @@ let _localizable = {
 		"en": "disconnected",
 		"de": "getrennt"
 	},
+	"captured_something": {
+		"ru": "captured something",
+		"en": "captured something",
+		"de": "hat irgendwas gekapert"
+	},
 	"captured_flag": {
 		"ru": "захватил флаг",
 		"en": "captured the flag",

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -256,7 +256,8 @@ class CapturedEvent extends GameEvent {
 
 		const markerVisible = this.markerIsVisible(f);
 		if (!this._marker && markerVisible) {
-			this._marker = L.marker.pulse(armaToLatLng(this.objectPosition), {iconSize: [50,50], color: 'red', fillColor: 'transparent', iterationCount: 1}).addTo(map);
+			const color = "#" + getMarkerColor(this.unitColor, "000000");
+			this._marker = L.marker.pulse(armaToLatLng(this.objectPosition), {iconSize: [50,50], color: color, fillColor: 'transparent', iterationCount: 1}).addTo(map);
 		} else if (this._marker && !markerVisible) {
 			this._marker.remove();
 			this._marker = null;

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -256,7 +256,7 @@ class CapturedEvent extends GameEvent {
 
 		const markerVisible = this.markerIsVisible(f);
 		if (!this._marker && markerVisible) {
-			const color = "#" + getMarkerColor(this.unitColor, "000000");
+			const color = "#" + getPulseMarkerColor(this.unitColor);
 			this._marker = L.marker.pulse(armaToLatLng(this.objectPosition), {iconSize: [50,50], color: color, fillColor: 'transparent', iterationCount: 1}).addTo(map);
 		} else if (this._marker && !markerVisible) {
 			this._marker.remove();

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -197,13 +197,13 @@ class ConnectEvent extends GameEvent {
 }
 
 class CapturedEvent extends GameEvent {
-	constructor(frameNum, type, unitName, unitColor, objectColor, objectPosition, objectType) {
+	constructor(frameNum, type, objectType, unitName, unitColor, objectColor, objectPosition) {
 		super(frameNum, type);
+		this.objectType = objectType;
 		this.unitName = unitName;
 		this.unitColor = unitColor;
 		this.objectColor = objectColor;
 		this.objectPosition = objectPosition;
-		this.objectType = objectType;
 		this._marker = null;
 
 		let icon = "hd_unknown";

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -971,3 +971,27 @@ function getMarkerColor(color, defaultColor = "ffffff") {
 function colorMarkerIcon(element, icon, color) {
 	element.src = `/images/markers/${icon}/${getMarkerColor(color)}.png`;
 }
+
+
+function getPulseMarkerColor(color, defaultColor = "000000") {
+	let hexColor = defaultColor;
+	if (!color) {
+		return hexColor;
+	}
+
+	if (color === "EAST") {
+		hexColor = "ff0000";
+	} else if (color === "WEST") {
+		hexColor = "004c99";
+	} else if (color === "IND") {
+		hexColor = "00cc00";
+	} else if (color === "CIV") {
+		hexColor = "C900FF";
+	} else if (color && color.startsWith('#')) {
+		hexColor = color.substring(1);
+	} else {
+		console.warn("unknown color", color);
+	}
+
+	return hexColor;
+}

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -710,11 +710,19 @@ function processOp (filepath) {
 				case (type == "connected" || type == "disconnected"):
 					gameEvent = new ConnectEvent(frameNum, type, eventJSON[2]);
 					break;
-				case (type === "capturedFlag"):
-					gameEvent = new CapturedEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2], eventJSON[2][3], "flag");
+				case (type === "capturedFlag"): // deprecated
+					gameEvent = new CapturedEvent(frameNum, type, "flag", eventJSON[2][0], eventJSON[2][1], eventJSON[2][2], eventJSON[2][3]);
 					break;
 				case (type === "captured"):
-					gameEvent = new CapturedEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2], eventJSON[2][3], eventJSON[2][4]);
+					gameEvent = new CapturedEvent(
+						frameNum,
+						type,
+						eventJSON[2][0], // capture type
+						eventJSON[2][1], // unit name
+						eventJSON[2][2], // unit color
+						eventJSON[2][3], // objective color
+						eventJSON[2][4], // objective position
+					);
 					break;
 				case (type === "terminalHackStarted"):
 					gameEvent = new TerminalHackStartEvent(

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -710,8 +710,11 @@ function processOp (filepath) {
 				case (type == "connected" || type == "disconnected"):
 					gameEvent = new ConnectEvent(frameNum, type, eventJSON[2]);
 					break;
-				case (type == "capturedFlag"):
-					gameEvent = new CaptureFlagEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2]);
+				case (type === "capturedFlag"):
+					gameEvent = new CapturedEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2], eventJSON[2][3], "flag");
+					break;
+				case (type === "captured"):
+					gameEvent = new CapturedEvent(frameNum, type, eventJSON[2][0], eventJSON[2][1], eventJSON[2][2], eventJSON[2][3], eventJSON[2][4]);
 					break;
 				case (type === "terminalHackStarted"):
 					gameEvent = new TerminalHackStartEvent(

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -945,24 +945,29 @@ function colorElement(element, color) {
 		element.style.color = color;
 	}
 }
-function colorMarkerIcon(element, icon, color) {
+
+function getMarkerColor(color, defaultColor = "ffffff") {
+	let hexColor = defaultColor;
 	if (!color) {
-		element.src = `/images/markers/${icon}/ffffff.png`;
-		return;
+		return hexColor;
 	}
 
 	if (color === "EAST") {
-		element.src = `/images/markers/${icon}/ff0000.png`;
+		hexColor = "ff0000";
 	} else if (color === "WEST") {
-		element.src = `/images/markers/${icon}/00a8ff.png`;
+		hexColor = "00a8ff";
 	} else if (color === "IND") {
-		element.src = `/images/markers/${icon}/00cc00.png`;
+		hexColor = "00cc00";
 	} else if (color === "CIV") {
-		element.src = `/images/markers/${icon}/C900FF.png`;
+		hexColor = "C900FF";
 	} else if (color && color.startsWith('#')) {
-		element.src = `/images/markers/${icon}/${color.substring(1)}.png`;
+		hexColor = color.substring(1);
 	} else {
-		console.warn("unknown icon color", color, icon);
-		element.src = `/images/markers/${icon}/ffffff.png`;
+		console.warn("unknown color", color);
 	}
+
+	return hexColor;
+}
+function colorMarkerIcon(element, icon, color) {
+	element.src = `/images/markers/${icon}/${getMarkerColor(color)}.png`;
 }


### PR DESCRIPTION
Docs: https://github.com/OCAP2/OCAP/wiki/Custom-Game-Events#captured-captured

This will be the final version of it, maybe add some more types later if needed.

New `getPulseMarkerColor` function, because colors for pulse markers looks a little bit different, and to make them better to identify should use this method.

related to https://github.com/OCAP2/OCAP/issues/7