### PR TITLE
Use causedBy for victim if disconnected at same frame

### DIFF
--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -104,11 +104,12 @@ class HitKilledEvent extends GameEvent {
 			const disconnectEvent = gameEvents.getEventsAtFrame(this.frameNum).find((v) => v instanceof ConnectEvent && v.type === "disconnected" && v.unitName === this.victim.getName());
 			if (disconnectEvent) {
 				this.causedBy = this.victim;
+				this.weapon = "Disconnect";
 			} else {
 				this.causedBy = new Unit(null, null, getLocalizable("something"), null, null, null, null); // Dummy unit
+				this.weapon = "N/A";
 			}
 			this.distance = 0;
-			this.weapon = "N/A";
 		}
 
 		// === Create UI element for this event (for later use)

--- a/static/scripts/ocap.event.js
+++ b/static/scripts/ocap.event.js
@@ -101,9 +101,14 @@ class HitKilledEvent extends GameEvent {
 		// If causedBy is null, victim was likely killed/hit by collision/fire/exploding vehicle
 		// TODO: Use better way of handling this
 		if (this.causedBy == null) {
+			const disconnectEvent = gameEvents.getEventsAtFrame(this.frameNum).find((v) => v instanceof ConnectEvent && v.type === "disconnected" && v.unitName === this.victim.getName());
+			if (disconnectEvent) {
+				this.causedBy = this.victim;
+			} else {
+				this.causedBy = new Unit(null, null, getLocalizable("something"), null, null, null, null); // Dummy unit
+			}
 			this.distance = 0;
 			this.weapon = "N/A";
-			this.causedBy = new Unit(null, null, getLocalizable("something"), null, null, null, null); // Dummy unit
 		}
 
 		// === Create UI element for this event (for later use)

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -694,8 +694,7 @@ function processOp (filepath) {
 
 					// TODO: Find out why victim/causedBy can sometimes be null
 					if (causedBy == null || (victim == null)) {
-						console.log(victim);
-						console.log(causedBy);
+						console.warn("unknown victim/causedBy", victim, causedBy);
 					}
 
 					// Incrememt kill/death count for killer/victim


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1900106/126020587-23f816b3-6e60-4e63-adf8-78741629714e.png)

`causedBy` was null, if this is the case check for a disconnect event at same frame and use the victim as the causedBy, because this is the normal suicide handling.

Maybe some kind of prepartion for https://github.com/OCAP2/OCAP/issues/12