### PR TITLE
Early exit in Vehicle._updateAtFrame

### DIFF
--- a/static/scripts/ocap.vehicle.js
+++ b/static/scripts/ocap.vehicle.js
@@ -72,6 +72,7 @@ class Vehicle extends Entity {
 
 	_updateAtFrame(relativeFrameIndex) {
 		super._updateAtFrame(relativeFrameIndex);
+		if (!position) return;
 
 		const position = this.getPosAtFrame(relativeFrameIndex);
 		this.setCrew(position.crew);

--- a/static/scripts/ocap.vehicle.js
+++ b/static/scripts/ocap.vehicle.js
@@ -72,9 +72,9 @@ class Vehicle extends Entity {
 
 	_updateAtFrame(relativeFrameIndex) {
 		super._updateAtFrame(relativeFrameIndex);
-		if (!position) return;
 
 		const position = this.getPosAtFrame(relativeFrameIndex);
+		if (!position) return;
 		this.setCrew(position.crew);
 	}
 


### PR DESCRIPTION
- title

If this is not handled playback can stop. Added same safeguard as in parent Entity class.
https://github.com/OCAP2/web/blob/main/static/scripts/ocap.entity.js#L188