### PR TITLE
use cloud tiles as fallback

### DIFF
--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -379,7 +379,7 @@ function initMap (world) {
 	let colorReliefLayerUrl = "";
 	let contourLayerUrl = "";
 
-	console.log('useCloudTiles', Boolean(useCloudTiles));
+	console.log('world._useCloudTiles', Boolean(world._useCloudTiles));
 	switch (world._useCloudTiles) {
 		case true: {
 			topoLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/{z}/{x}/{y}.png');

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -193,11 +193,11 @@ async function getWorldByName (worldName) {
 			try {
 				return Object.assign(defaultMap, await cloudMapRes.json(), {_useCloudTiles:true});
 			} catch (error) {
-				//ui.showHint(`Error: parsing cloud map.json`);
 				console.error('Error parsing cloud map.json', error.message || error);
+				return Promise.reject(`Cloud map "${worldName}" data parsing failed.`);
 			}
 		} else {
-			return Promise.reject(`Map "${worldName}" is not installed on cloud`);
+			return Promise.reject(`Map "${worldName}" is not available on cloud (${cloudMapRes.status})`);
 		}
 	} else {
 		return Promise.reject(`Map "${worldName}" is not installed`);

--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -380,23 +380,18 @@ function initMap (world) {
 	let contourLayerUrl = "";
 
 	console.log('world._useCloudTiles', Boolean(world._useCloudTiles));
-	switch (world._useCloudTiles) {
-		case true: {
-			topoLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/{z}/{x}/{y}.png');
-			topoDarkLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/topoDark/{z}/{x}/{y}.png');
-			topoReliefLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/topoRelief/{z}/{x}/{y}.png');
-			colorReliefLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/colorRelief/{z}/{x}/{y}.png');
-			contourLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/contours.geojson');
-			break;
-		}
-		case false: {
-			topoLayerUrl = ('images/maps/' + worldName + '/{z}/{x}/{y}.png');
-			topoDarkLayerUrl = ('images/maps/' + worldName + '/topoDark/{z}/{x}/{y}.png');
-			topoReliefLayerUrl = ('images/maps/' + worldName + '/topoRelief/{z}/{x}/{y}.png');
-			colorReliefLayerUrl = ('images/maps/' + worldName + '/colorRelief/{z}/{x}/{y}.png');
-			contourLayerUrl = ('images/maps/' + worldName + '/contours.geojson');
-			break;
-		}
+	if (Boolean(world._useCloudTiles)) {
+		topoLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/{z}/{x}/{y}.png');
+		topoDarkLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/topoDark/{z}/{x}/{y}.png');
+		topoReliefLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/topoRelief/{z}/{x}/{y}.png');
+		colorReliefLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/colorRelief/{z}/{x}/{y}.png');
+		contourLayerUrl = ('https://maps.ocap2.com/' + worldName.toLowerCase() + '/contours.geojson');
+	} else {
+		topoLayerUrl = ('images/maps/' + worldName + '/{z}/{x}/{y}.png');
+		topoDarkLayerUrl = ('images/maps/' + worldName + '/topoDark/{z}/{x}/{y}.png');
+		topoReliefLayerUrl = ('images/maps/' + worldName + '/topoRelief/{z}/{x}/{y}.png');
+		colorReliefLayerUrl = ('images/maps/' + worldName + '/colorRelief/{z}/{x}/{y}.png');
+		contourLayerUrl = ('images/maps/' + worldName + '/contours.geojson');
 	}
 
 	if (world.hasTopo) {


### PR DESCRIPTION
related issue: https://github.com/OCAP2/web/pull/42#issuecomment-1118637082

changes:
 * converts `getWorldByName` to async function
   * checks for a local map.json first, then falls back to the cloud cdn if enabled (`ui.useCloudTiles`)
   * if cloud is used `_useCloudTiles` property is injected into the world data (checked in `initMap` fn)
 * refactored promise chain in `processOp` fn a bit to leverage the `catch` fn to show errors properly