### PR TITLE
Regional time calls changed to UTC for date display

### DIFF
--- a/static/scripts/ocap.js
+++ b/static/scripts/ocap.js
@@ -363,7 +363,7 @@ function armaToLatLng (coords) {
 
 // Returns date object as little endian (day, month, year) string
 function dateToLittleEndianString (date) {
-	return (date.getDate() + "/" + (date.getMonth() + 1) + "/" + date.getFullYear());
+	return (date.getUTCDate() + "/" + (date.getUTCMonth() + 1) + "/" + date.getUTCFullYear());
 }
 
 function test () {


### PR DESCRIPTION
Mission dates in selection menu display a day off in all time zones earlier than UTC due to improper date conversion. See below for more details: https://discord.com/channels/858402673066115102/871034165271855125/1279682140203913320