### PR TITLE
fix: use meta.json worldName for maptool uploads

### DIFF
--- a/internal/maptool/worldmeta.go
+++ b/internal/maptool/worldmeta.go
@@ -38,7 +38,32 @@ func ReadGradMehMeta(dir string) (GradMehMeta, error) {
 		return GradMehMeta{}, fmt.Errorf("meta.json: worldSize must be positive, got %v", meta.WorldSize)
 	}
 	meta.WorldName = strings.ToLower(meta.WorldName)
+	if !isSafeWorldName(meta.WorldName) {
+		return GradMehMeta{}, fmt.Errorf("meta.json: worldName %q is not a safe directory name", meta.WorldName)
+	}
 	return meta, nil
+}
+
+// isSafeWorldName reports whether name is safe to use as a single-segment
+// directory name. It rejects path separators, traversal segments, and any
+// characters outside [a-z0-9_-].
+func isSafeWorldName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if filepath.Base(name) != name {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateGradMehDir checks that a directory contains a valid grad_meh export.

--- a/internal/server/handler_maptool.go
+++ b/internal/server/handler_maptool.go
@@ -144,8 +144,12 @@ func (h *Handler) importMapToolZip(c ContextNoBody) (maptool.JobInfo, error) {
 		return maptool.JobInfo{}, fuego.BadRequestError{Detail: fmt.Sprintf("not a valid grad_meh export: %v", err)}
 	}
 
-	worldName := maptool.WorldNameFromDir(gradMehDir)
-	snap, err := h.maptoolMgr.SubmitWithCleanup(gradMehDir, worldName, extractDir)
+	meta, err := maptool.ReadGradMehMeta(gradMehDir)
+	if err != nil {
+		os.RemoveAll(extractDir)
+		return maptool.JobInfo{}, fuego.BadRequestError{Detail: fmt.Sprintf("invalid grad_meh meta.json: %v", err)}
+	}
+	snap, err := h.maptoolMgr.SubmitWithCleanup(gradMehDir, meta.WorldName, extractDir)
 	if err != nil {
 		os.RemoveAll(extractDir)
 		return maptool.JobInfo{}, fuego.InternalServerError{Err: err, Detail: "failed to submit import job"}


### PR DESCRIPTION
## Summary
- Maptool uploads were saving maps under names like `ocap-maptool-uploads-1517127726-1777287006640` instead of the actual world name (e.g. `stratis`) when users zipped the **contents** of a grad_meh export directory rather than the directory itself.
- Root cause: `handler_maptool.go` derived `worldName` from the basename of the extraction directory via `WorldNameFromDir`. When `meta.json` and `sat/` sit at the zip root, `FindGradMehDir` returns the temp extraction dir, whose basename is the temp-dir name. That name was then used to create `mapsDir/<worldName>` and the job ID before the pipeline's `parse_gradmeh` stage corrected `job.WorldName` from `meta.json`.
- Fix: read `meta.json` upfront in the handler via `ReadGradMehMeta` and submit the authoritative worldName to the job manager.

## Test plan
- [x] Upload a zip containing the `stratis/` folder — saved as `stratis` (regression check)
- [x] Upload a zip with `meta.json` + `sat/` at the root — saved as `stratis` (the bug case)
- [ ] Upload a zip without a valid `meta.json` — returns a clear 400 error