### PR TITLE
feat: keep AI vehicle labels visible in 'players' name mode

### DIFF
--- a/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
+++ b/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
@@ -915,6 +915,39 @@ describe("EntityCanvasLayer — render paths", () => {
     expect(texts).not.toContain("AI Unit");
   });
 
+  it("shows AI vehicle type labels in 'players' mode", () => {
+    (layer as any).config.nameDisplayMode = () => "players";
+    layer.addEntity(1, {
+      ...DEFAULT_OPTS,
+      isPlayer: false,
+      name: "T-72",
+      crew: { count: 3, names: [] },
+    });
+    layer.addEntity(2, {
+      ...DEFAULT_OPTS,
+      isPlayer: false,
+      name: "AI Rifleman",
+      position: [1100, 2000],
+    });
+    render();
+    const texts = mockCtx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(texts).toContain("T-72 (3)");
+    expect(texts).not.toContain("AI Rifleman");
+  });
+
+  it("hides AI vehicle type labels when nameMode is 'none'", () => {
+    (layer as any).config.nameDisplayMode = () => "none";
+    layer.addEntity(1, {
+      ...DEFAULT_OPTS,
+      isPlayer: false,
+      name: "T-72",
+      crew: { count: 3, names: [] },
+    });
+    render();
+    const texts = mockCtx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(texts).not.toContain("T-72 (3)");
+  });
+
   it("renders vehicle crew label with background pill", () => {
     layer.addEntity(1, {
       ...DEFAULT_OPTS,

--- a/ui/src/renderers/leaflet/entityCanvasLayer.ts
+++ b/ui/src/renderers/leaflet/entityCanvasLayer.ts
@@ -875,12 +875,15 @@ export class EntityCanvasLayer {
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       }
 
-      // Draw label (not rotated, positioned above icon, counter-scaled during zoom)
+      // Draw label (not rotated, positioned above icon, counter-scaled during zoom).
+      // Vehicle types stay visible in "players" mode so AI vehicles can still be
+      // identified without showing every AI infantry name.
+      const isVehicle = e.crew !== undefined;
       if (
         !hideLabels &&
         nameMode !== "none" &&
         !e.isInVehicle &&
-        (nameMode === "all" || (nameMode === "players" && e.isPlayer))
+        (nameMode === "all" || e.isPlayer || isVehicle)
       ) {
         const [, ih] = e.iconSize;
         const crew = e.crew;

--- a/ui/src/renderers/leaflet/leafletRenderer.ts
+++ b/ui/src/renderers/leaflet/leafletRenderer.ts
@@ -49,6 +49,7 @@ interface InternalMarkerHandle {
   /** Per-entity state for popup visibility — kept in sync by updateEntityMarker. */
   isPlayer: boolean;
   isInVehicle: boolean;
+  isVehicle: boolean;
 }
 
 interface InternalBriefingHandle {
@@ -779,7 +780,7 @@ export class LeafletRenderer implements MapRenderer {
     marker.bindPopup(popup).openPopup();
 
     const iconKey = `${opts.iconType}:${opts.side}:1`;
-    const internal: InternalMarkerHandle = { marker, id, lastDirection: 0, iconKey, popupName: popupContent, isPlayer: opts.isPlayer, isInVehicle: false };
+    const internal: InternalMarkerHandle = { marker, id, lastDirection: 0, iconKey, popupName: popupContent, isPlayer: opts.isPlayer, isInVehicle: false, isVehicle: opts.crew !== undefined };
     (marker as any)._ocapInternal = internal;
     return wrapMarker(internal);
   }
@@ -791,6 +792,7 @@ export class LeafletRenderer implements MapRenderer {
     // Keep per-entity state in sync for refreshPopupVisibility
     internal.isPlayer = state.isPlayer;
     internal.isInVehicle = state.isInVehicle;
+    internal.isVehicle = state.crew !== undefined;
 
     // Update position
     const latlng = this.armaToLatLng(state.position);
@@ -833,7 +835,11 @@ export class LeafletRenderer implements MapRenderer {
           display = "none";
         } else if (this._nameDisplayMode() === "none") {
           display = "none";
-        } else if (this._nameDisplayMode() === "players" && !state.isPlayer) {
+        } else if (
+          this._nameDisplayMode() === "players" &&
+          !state.isPlayer &&
+          !internal.isVehicle
+        ) {
           display = "none";
         }
         popupEl.style.display = display;
@@ -1244,7 +1250,12 @@ export class LeafletRenderer implements MapRenderer {
         display = "none";
       } else if (this._nameDisplayMode() === "none") {
         display = "none";
-      } else if (this._nameDisplayMode() === "players" && internal && !internal.isPlayer) {
+      } else if (
+        this._nameDisplayMode() === "players" &&
+        internal &&
+        !internal.isPlayer &&
+        !internal.isVehicle
+      ) {
         display = "none";
       }
       popupEl.style.display = display;

--- a/ui/src/renderers/leaflet/leafletRenderer.ts
+++ b/ui/src/renderers/leaflet/leafletRenderer.ts
@@ -780,7 +780,16 @@ export class LeafletRenderer implements MapRenderer {
     marker.bindPopup(popup).openPopup();
 
     const iconKey = `${opts.iconType}:${opts.side}:1`;
-    const internal: InternalMarkerHandle = { marker, id, lastDirection: 0, iconKey, popupName: popupContent, isPlayer: opts.isPlayer, isInVehicle: false, isVehicle: opts.crew !== undefined };
+    const internal: InternalMarkerHandle = {
+      marker,
+      id,
+      lastDirection: 0,
+      iconKey,
+      popupName: popupContent,
+      isPlayer: opts.isPlayer,
+      isInVehicle: false,
+      isVehicle: opts.crew !== undefined,
+    };
     (marker as any)._ocapInternal = internal;
     return wrapMarker(internal);
   }


### PR DESCRIPTION
## Summary

User feedback:
> It would be nice if AI's vehicle types would be visible at all times without having to have all AI's names (which cause clutter) visible. Very rarely you really care about individual AI's names, but you do care about type of vehicle they're driving.

In `players` mode the map now shows vehicle labels (e.g. "T-72 (3)") regardless of crew, while AI infantry names stay hidden. The `none` mode still hides everything, so the existing "hide all labels" escape hatch is preserved.

## Behaviour matrix

| nameMode  | Player infantry | AI infantry | Player vehicle | AI vehicle |
|-----------|-----------------|-------------|----------------|------------|
| `all`     | shown           | shown       | shown          | shown      |
| `players` | shown           | hidden      | shown          | **shown** (was hidden) |
| `none`    | hidden          | hidden      | hidden         | hidden     |

Applies to both the canvas renderer (default) and the DOM Leaflet renderer (`?renderer=dom` fallback).

## Test plan

- [x] `npm test` (1497 tests, includes 2 new ones for the `players`-mode vehicle case and the `none` suppression case)
- [x] `tsc --noEmit` clean
- [ ] Manually verify on a recording with mixed AI/player crews that AI vehicle labels appear in `players` mode and disappear in `none` mode