### PR TITLE
refactor: move stat-pill state colors into CSS modules

### DIFF
--- a/ui/src/pages/recording-playback/components/SidePanel.module.css
+++ b/ui/src/pages/recording-playback/components/SidePanel.module.css
@@ -329,7 +329,7 @@
 }
 
 .detailStatValueMarkers {
-  color: #a78bfa;
+  color: var(--accent-purple);
 }
 
 .detailStatLabel {

--- a/ui/src/pages/recording-playback/components/SidePanel.module.css
+++ b/ui/src/pages/recording-playback/components/SidePanel.module.css
@@ -317,6 +317,19 @@
   font-weight: 700;
   font-family: var(--font-mono);
   line-height: 1;
+  color: var(--text-dimmest);
+}
+
+.detailStatValueKills {
+  color: var(--accent-danger);
+}
+
+.detailStatValueDeaths {
+  color: var(--accent-warning);
+}
+
+.detailStatValueMarkers {
+  color: #a78bfa;
 }
 
 .detailStatLabel {
@@ -607,6 +620,23 @@
   font-weight: 700;
   font-family: var(--font-mono);
   line-height: 1;
+  color: var(--text-dimmest);
+}
+
+.forceStatNumTotal {
+  color: var(--text-secondary);
+}
+
+.forceStatNumAlive {
+  color: var(--accent-success);
+}
+
+.forceStatNumKills {
+  color: var(--accent-danger);
+}
+
+.forceStatNumDeaths {
+  color: var(--accent-warning);
 }
 
 .forceStatLabel {

--- a/ui/src/pages/recording-playback/components/StatsTab.tsx
+++ b/ui/src/pages/recording-playback/components/StatsTab.tsx
@@ -115,13 +115,13 @@ export function StatsTab(): JSX.Element {
                     </div>
                     <div class={styles.forceStatGrid}>
                       <div class={styles.forceStatPill}>
-                        <div class={styles.forceStatNum} style={{ color: "var(--text-secondary)" }}>
+                        <div class={`${styles.forceStatNum} ${styles.forceStatNumTotal}`}>
                           {stat.total}
                         </div>
                         <div class={styles.forceStatLabel}>{t("total")}</div>
                       </div>
                       <div class={styles.forceStatPill}>
-                        <div class={styles.forceStatNum} style={{ color: "var(--accent-success)" }}>
+                        <div class={`${styles.forceStatNum} ${styles.forceStatNumAlive}`}>
                           {stat.alive}
                         </div>
                         <div class={styles.forceStatLabel}>{t("alive")}</div>
@@ -129,7 +129,7 @@ export function StatsTab(): JSX.Element {
                       <div class={styles.forceStatPill}>
                         <div
                           class={styles.forceStatNum}
-                          style={{ color: stat.kills > 0 ? "var(--accent-danger)" : "var(--text-dimmest)" }}
+                          classList={{ [styles.forceStatNumKills]: stat.kills > 0 }}
                         >
                           {stat.kills}
                         </div>
@@ -138,7 +138,7 @@ export function StatsTab(): JSX.Element {
                       <div class={styles.forceStatPill}>
                         <div
                           class={styles.forceStatNum}
-                          style={{ color: stat.deaths > 0 ? "var(--accent-warning)" : "var(--text-dimmest)" }}
+                          classList={{ [styles.forceStatNumDeaths]: stat.deaths > 0 }}
                         >
                           {stat.deaths}
                         </div>

--- a/ui/src/pages/recording-playback/components/UnitsTab.tsx
+++ b/ui/src/pages/recording-playback/components/UnitsTab.tsx
@@ -286,7 +286,7 @@ function UnitDetailCard(props: UnitDetailCardProps): JSX.Element {
           <div class={styles.detailStatPill}>
             <div
               class={styles.detailStatValue}
-              style={{ color: props.kills > 0 ? "var(--accent-danger)" : "var(--text-dimmest)" }}
+              classList={{ [styles.detailStatValueKills]: props.kills > 0 }}
             >
               {props.kills}
             </div>
@@ -295,7 +295,7 @@ function UnitDetailCard(props: UnitDetailCardProps): JSX.Element {
           <div class={styles.detailStatPill}>
             <div
               class={styles.detailStatValue}
-              style={{ color: props.deaths > 0 ? "var(--accent-warning)" : "var(--text-dimmest)" }}
+              classList={{ [styles.detailStatValueDeaths]: props.deaths > 0 }}
             >
               {props.deaths}
             </div>
@@ -309,7 +309,7 @@ function UnitDetailCard(props: UnitDetailCardProps): JSX.Element {
               <>
                 <div
                   class={styles.detailStatValue}
-                  style={{ color: visible > 0 ? "#A78BFA" : "var(--text-dimmest)" }}
+                  classList={{ [styles.detailStatValueMarkers]: visible > 0 }}
                 >
                   {visible}
                 </div>


### PR DESCRIPTION
## Summary
- Follow-up to #405 review feedback: replace conditional inline color styles in `UnitsTab` and `StatsTab` stat pills with semantic CSS module classes.
- Adds modifier classes `detailStatValueKills/Deaths/Markers` and `forceStatNumTotal/Alive/Kills/Deaths` on the existing base classes; default color falls back to `--text-dimmest`.

## Test plan
- [x] `npx vitest run src/pages/recording-playback/ src/hooks/__tests__/useCustomize.test.tsx` (320 tests pass)
- [x] `npx tsc --noEmit`
- [ ] Visual regression: stat pills in unit detail card and force summary unchanged.