### PR TITLE
fix: Node.js v25 / Windows compatibility and locale-aware number formatting

### DIFF
--- a/ui/src/pages/map-manager/MapDetail.tsx
+++ b/ui/src/pages/map-manager/MapDetail.tsx
@@ -17,7 +17,7 @@ export function MapDetail(props: {
   onClose: () => void;
   onDelete: () => void;
 }): JSX.Element {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const hue = () => mapHue(props.map.name);
 
   return (
@@ -69,7 +69,7 @@ export function MapDetail(props: {
             <div class={styles.infoItem}>
               <div class={styles.infoLabel}>{t("mm_world_size")}</div>
               <div class={styles.infoValue} style={{ color: "var(--text-muted)" }}>
-                {props.map.worldSize!.toLocaleString()} m
+                {props.map.worldSize!.toLocaleString(locale())} m
               </div>
             </div>
           </Show>

--- a/ui/src/pages/recording-selector/DetailSidebar.tsx
+++ b/ui/src/pages/recording-selector/DetailSidebar.tsx
@@ -125,19 +125,19 @@ export function DetailSidebar(props: {
                           </div>
                           <div class={styles.sideCardStats}>
                             <div class={styles.sideCardStat}>
-                              <div class={styles.sideCardStatValue}>{count.units.toLocaleString()}</div>
+                              <div class={styles.sideCardStatValue}>{count.units.toLocaleString(locale())}</div>
                               <div class={styles.sideCardStatLabel}>{t("total")}</div>
                             </div>
                             <div class={styles.sideCardStat}>
-                              <div class={styles.sideCardStatValue} style={{ color: alive() > 0 ? C.success : C.dimmer }}>{alive().toLocaleString()}</div>
+                              <div class={styles.sideCardStatValue} style={{ color: alive() > 0 ? C.success : C.dimmer }}>{alive().toLocaleString(locale())}</div>
                               <div class={styles.sideCardStatLabel}>{t("alive")}</div>
                             </div>
                             <div class={styles.sideCardStat}>
-                              <div class={styles.sideCardStatValue} style={{ color: dead() > 0 ? C.danger : C.dimmer }}>{dead().toLocaleString()}</div>
+                              <div class={styles.sideCardStatValue} style={{ color: dead() > 0 ? C.danger : C.dimmer }}>{dead().toLocaleString(locale())}</div>
                               <div class={styles.sideCardStatLabel}>{t("dead")}</div>
                             </div>
                             <div class={styles.sideCardStat}>
-                              <div class={styles.sideCardStatValue} style={{ color: kills() > 0 ? C.warning : C.dimmer }}>{kills().toLocaleString()}</div>
+                              <div class={styles.sideCardStatValue} style={{ color: kills() > 0 ? C.warning : C.dimmer }}>{kills().toLocaleString(locale())}</div>
                               <div class={styles.sideCardStatLabel}>{t("kills_label")}</div>
                             </div>
                           </div>
@@ -165,7 +165,7 @@ export function DetailSidebar(props: {
                 <div class={styles.sidebarCombatCell} style={{ background: "color-mix(in srgb, var(--accent-danger) 4%, transparent)", "border-color": "color-mix(in srgb, var(--accent-danger) 8%, transparent)" }}>
                   <div class={styles.sidebarCombatCellTop}>
                     <span class={styles.sidebarCombatIcon}><CrosshairIcon /></span>
-                    <span class={styles.sidebarCombatCellValue} style={{ color: C.danger }}>{kills().toLocaleString()}</span>
+                    <span class={styles.sidebarCombatCellValue} style={{ color: C.danger }}>{kills().toLocaleString(locale())}</span>
                   </div>
                   <div class={styles.sidebarCombatCellLabel}>{t("total_kills")}</div>
                 </div>
@@ -173,7 +173,7 @@ export function DetailSidebar(props: {
                   <div class={styles.sidebarCombatCell} style={{ background: "color-mix(in srgb, var(--accent-primary) 4%, transparent)", "border-color": "color-mix(in srgb, var(--accent-primary) 8%, transparent)" }}>
                     <div class={styles.sidebarCombatCellTop}>
                       <span style={{ color: `${C.primary}88` }}><UsersIcon /></span>
-                      <span class={styles.sidebarCombatCellValue} style={{ color: C.primary }}>{playerKills().toLocaleString()}</span>
+                      <span class={styles.sidebarCombatCellValue} style={{ color: C.primary }}>{playerKills().toLocaleString(locale())}</span>
                     </div>
                     <div class={styles.sidebarCombatCellLabel}>{t("player_kills")}</div>
                   </div>

--- a/ui/src/testSetup.ts
+++ b/ui/src/testSetup.ts
@@ -1,3 +1,34 @@
+// Node.js v22.12+ exposes localStorage as a native global. In v25 it is SQLite-backed
+// and requires --localstorage-file; without it the object exists but getItem/setItem
+// are not functions, which breaks jsdom's own storage mock. Replace it with a plain
+// in-memory store whenever the native version is broken.
+if (
+  typeof localStorage !== "undefined" &&
+  typeof localStorage.getItem !== "function"
+) {
+  const _store: Record<string, string> = {};
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => _store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        _store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete _store[key];
+      },
+      clear: () => {
+        for (const k in _store) delete _store[k];
+      },
+      get length() {
+        return Object.keys(_store).length;
+      },
+      key: (i: number) => Object.keys(_store)[i] ?? null,
+    } satisfies Storage,
+    writable: true,
+    configurable: true,
+  });
+}
+
 // Polyfill ResizeObserver for JSDOM (needed by @tanstack/virtual)
 if (typeof globalThis.ResizeObserver === "undefined") {
   globalThis.ResizeObserver = class ResizeObserver {

--- a/ui/src/testSetup.ts
+++ b/ui/src/testSetup.ts
@@ -6,7 +6,7 @@ if (
   typeof localStorage !== "undefined" &&
   typeof localStorage.getItem !== "function"
 ) {
-  const _store: Record<string, string> = {};
+  const _store: Record<string, string> = Object.create(null);
   Object.defineProperty(globalThis, "localStorage", {
     value: {
       getItem: (key: string) => _store[key] ?? null,

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,8 +1,25 @@
 import { defineConfig } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
-  plugins: [solidPlugin()],
+  plugins: [
+    {
+      name: "fix-solid-refresh-path",
+      enforce: "pre",
+      // On Windows, fileURLToPath rejects 'file:///@solid-refresh' because the path
+      // has no drive letter. Redirect to the actual file before solidPlugin's resolveId
+      // returns the virtual ID, so the module ID is always a real file path.
+      resolveId(id: string) {
+        if (id === "/@solid-refresh") {
+          return require.resolve("solid-refresh/dist/solid-refresh.mjs");
+        }
+      },
+    },
+    solidPlugin(),
+  ],
   resolve: {
     conditions: ["development", "browser"],
     dedupe: ["solid-js", "solid-js/web", "solid-js/store"],


### PR DESCRIPTION
## Summary

Fixes three test failures that appear when running `npm test` locally on Windows with Node.js v25 (CI uses Ubuntu + Node.js v24 where none of these manifest):

- **`localStorage.getItem is not a function`** — Node.js v22.12+ exposes a native `localStorage` global (SQLite-backed in v25).
Without `--localstorage-file` the object exists but its methods are not functions, silently overriding jsdom's storage mock.
`testSetup.ts` now detects this and replaces the broken global with a plain in-memory `Storage` implementation.
- **`TypeError: … Received 'file:///@solid-refresh'`** — `vite-plugin-solid` registers `/@solid-refresh` as a virtual module ID; vitest 4 converts it to `file:///@solid-refresh`. On Windows, `fileURLToPath` rejects that URL because the path has no drive
letter. A new `enforce: "pre"` plugin in `vitest.config.ts` intercepts the ID and returns the real file path before solidPlugin can register the virtual one. Also removes the deprecated `poolOptions` block (removed in vitest 4).
- **Wrong thousands separator in tests** — `MapDetail.tsx` called `toLocaleString()` without a locale, so on a non-English Windows machine `30720` rendered as `"30 720"` instead of `"30,720"`. Now passes `locale()` from `useI18n()` explicitly.

## How to test

```bash
  cd ui && npm test
```

  Optionally verify on Windows with Node.js v25 — previously produced 40 failed test files and 9 failed tests.

## Checklist

- [x] `go test ./...` passes
- [x] `cd ui && npm test` passes (if frontend changed)
- [x] No breaking changes (or documented below)