### PR TITLE
feat: add configurable http timeouts

### DIFF
--- a/cmd/ocap-webserver/main.go
+++ b/cmd/ocap-webserver/main.go
@@ -91,6 +91,12 @@ func app() error {
 		),
 	)
 
+	// Apply HTTP server settings
+	s.Server.ReadTimeout = setting.HttpServer.ReadTimeout
+	s.Server.ReadHeaderTimeout = setting.HttpServer.ReadHeaderTimeout
+	s.Server.WriteTimeout = setting.HttpServer.WriteTimeout
+	s.Server.IdleTimeout = setting.HttpServer.IdleTimeout
+
 	// Create conversion worker if enabled (before handler so we can pass it)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -113,7 +113,41 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("httpServer.idleTimeout", "120s")
 
 	// workaround for https://github.com/spf13/viper/issues/761
-	envKeys := []string{"listen", "prefixURL", "secret", "db", "markers", "ammo", "fonts", "maps", "data", "static", "customize.enabled", "customize.websiteurl", "customize.websitelogo", "customize.websitelogosize", "customize.disableKillCount", "customize.headertitle", "customize.headersubtitle", "conversion.enabled", "conversion.interval", "conversion.batchSize", "conversion.chunkSize", "conversion.retryFailed", "streaming.enabled", "streaming.pingInterval", "streaming.pingTimeout", "auth.sessionTTL", "auth.adminSteamIds", "auth.steamApiKey", "httpServer.readTimeout", "httpServer.readHeaderTimeout", "httpServer.writeTimeout", "httpServer.idleTimeout"}
+	envKeys := []string{
+		"listen",
+		"prefixURL",
+		"secret",
+		"db",
+		"markers",
+		"ammo",
+		"fonts",
+		"maps",
+		"data",
+		"static",
+		"customize.enabled",
+		"customize.websiteurl",
+		"customize.websitelogo",
+		"customize.websitelogosize",
+		"customize.disableKillCount",
+		"customize.headertitle",
+		"customize.headersubtitle",
+		"conversion.enabled",
+		"conversion.interval",
+		"conversion.batchSize",
+		"conversion.chunkSize",
+		"conversion.retryFailed",
+		"streaming.enabled",
+		"streaming.pingInterval",
+		"streaming.pingTimeout",
+		"auth.sessionTTL",
+		"auth.adminSteamIds",
+		"auth.steamApiKey",
+		"httpServer.readTimeout",
+		"httpServer.readHeaderTimeout",
+		"httpServer.writeTimeout",
+		"httpServer.idleTimeout",
+	}
+
 	for _, key := range envKeys {
 		env := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
 		if err = viper.BindEnv(key, env); err != nil {

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -26,7 +26,8 @@ type Setting struct {
 	Customize  Customize  `json:"customize" yaml:"customize"`
 	Conversion Conversion `json:"conversion" yaml:"conversion"`
 	Streaming  Streaming  `json:"streaming" yaml:"streaming"`
-	Auth      Auth      `json:"auth" yaml:"auth"`
+	Auth       Auth       `json:"auth" yaml:"auth"`
+	HttpServer HttpServer `json:"httpServer" yaml:"httpServer"`
 }
 
 type Conversion struct {
@@ -38,11 +39,11 @@ type Conversion struct {
 }
 
 type Customize struct {
-	Enabled          bool   `json:"enabled" yaml:"enabled"`
-	WebsiteURL       string `json:"websiteURL" yaml:"websiteURL"`
-	WebsiteLogo      string `json:"websiteLogo" yaml:"websiteLogo"`
-	WebsiteLogoSize  string `json:"websiteLogoSize" yaml:"websiteLogoSize"`
-	DisableKillCount bool   `json:"disableKillCount" yaml:"disableKillCount"`
+	Enabled          bool              `json:"enabled" yaml:"enabled"`
+	WebsiteURL       string            `json:"websiteURL" yaml:"websiteURL"`
+	WebsiteLogo      string            `json:"websiteLogo" yaml:"websiteLogo"`
+	WebsiteLogoSize  string            `json:"websiteLogoSize" yaml:"websiteLogoSize"`
+	DisableKillCount bool              `json:"disableKillCount" yaml:"disableKillCount"`
 	HeaderTitle      string            `json:"headerTitle" yaml:"headerTitle"`
 	HeaderSubtitle   string            `json:"headerSubtitle" yaml:"headerSubtitle"`
 	CSSOverrides     map[string]string `json:"cssOverrides,omitempty" yaml:"cssOverrides"`
@@ -58,6 +59,13 @@ type Streaming struct {
 	Enabled      bool          `json:"enabled" yaml:"enabled"`
 	PingInterval time.Duration `json:"pingInterval" yaml:"pingInterval"`
 	PingTimeout  time.Duration `json:"pingTimeout" yaml:"pingTimeout"`
+}
+
+type HttpServer struct {
+	ReadTimeout       time.Duration `json:"readTimeout" yaml:"readTimeout"`
+	ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" yaml:"readHeaderTimeout"`
+	WriteTimeout      time.Duration `json:"writeTimeout" yaml:"writeTimeout"`
+	IdleTimeout       time.Duration `json:"idleTimeout" yaml:"idleTimeout"`
 }
 
 func NewSetting() (setting Setting, err error) {
@@ -99,9 +107,13 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("auth.adminSteamIds", []string{})
 	viper.SetDefault("auth.steamApiKey", "")
 
+	viper.SetDefault("httpServer.readTimeout", "120s")
+	viper.SetDefault("httpServer.readHeaderTimeout", "120s")
+	viper.SetDefault("httpServer.writeTimeout", "120s")
+	viper.SetDefault("httpServer.idleTimeout", "120s")
 
 	// workaround for https://github.com/spf13/viper/issues/761
-	envKeys := []string{"listen", "prefixURL", "secret", "db", "markers", "ammo", "fonts", "maps", "data", "static", "customize.enabled", "customize.websiteurl", "customize.websitelogo", "customize.websitelogosize", "customize.disableKillCount", "customize.headertitle", "customize.headersubtitle", "conversion.enabled", "conversion.interval", "conversion.batchSize", "conversion.chunkSize", "conversion.retryFailed", "streaming.enabled", "streaming.pingInterval", "streaming.pingTimeout", "auth.sessionTTL", "auth.adminSteamIds", "auth.steamApiKey"}
+	envKeys := []string{"listen", "prefixURL", "secret", "db", "markers", "ammo", "fonts", "maps", "data", "static", "customize.enabled", "customize.websiteurl", "customize.websitelogo", "customize.websitelogosize", "customize.disableKillCount", "customize.headertitle", "customize.headersubtitle", "conversion.enabled", "conversion.interval", "conversion.batchSize", "conversion.chunkSize", "conversion.retryFailed", "streaming.enabled", "streaming.pingInterval", "streaming.pingTimeout", "auth.sessionTTL", "auth.adminSteamIds", "auth.steamApiKey", "httpServer.readTimeout", "httpServer.readHeaderTimeout", "httpServer.writeTimeout", "httpServer.idleTimeout"}
 	for _, key := range envKeys {
 		env := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
 		if err = viper.BindEnv(key, env); err != nil {

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -108,7 +108,7 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("auth.steamApiKey", "")
 
 	viper.SetDefault("httpServer.readTimeout", "120s")
-	viper.SetDefault("httpServer.readHeaderTimeout", "120s")
+	viper.SetDefault("httpServer.readHeaderTimeout", "30s")
 	viper.SetDefault("httpServer.writeTimeout", "120s")
 	viper.SetDefault("httpServer.idleTimeout", "120s")
 

--- a/internal/server/setting_test.go
+++ b/internal/server/setting_test.go
@@ -200,7 +200,7 @@ func TestNewSetting_ConfigFile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
-			"--accent-blue":  "#FF6600",
+			"--accent-blue": "#FF6600",
 			"--side-blufor": "#00FF88",
 		}, setting.Customize.CSSOverrides)
 	})
@@ -306,6 +306,18 @@ func TestNewSetting_EnvVars(t *testing.T) {
 		assert.Equal(t, dbPath, setting.DB)
 		_, err = os.Stat(filepath.Dir(dbPath))
 		require.NoError(t, err, "database directory should have been created")
+	})
+
+	t.Run("OCAP_HTTPSERVER_READTIMEOUT env var", func(t *testing.T) {
+		viper.Reset()
+		viper.AddConfigPath(dir)
+
+		os.Setenv("OCAP_HTTPSERVER_READTIMEOUT", "60s")
+		defer os.Unsetenv("OCAP_HTTPSERVER_READTIMEOUT")
+
+		setting, err := NewSetting()
+		require.NoError(t, err)
+		assert.Equal(t, 60*time.Second, setting.HttpServer.ReadTimeout)
 	})
 
 	t.Run("OCAP_CUSTOMIZE_CSSOVERRIDES env var", func(t *testing.T) {
@@ -459,6 +471,33 @@ func TestSetting_AuthSteamAPIKey(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "ABCDEF0123456789", setting.Auth.SteamAPIKey)
+}
+
+func TestSetting_HttpServer(t *testing.T) {
+	defer viper.Reset()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "setting.json")
+	err := os.WriteFile(configPath, []byte(`{
+		"secret": "test-secret-value",
+		"httpServer": {
+			"readTimeout": "110s",
+			"readHeaderTimeout": "120s",
+			"writeTimeout": "130s",
+			"idleTimeout": "140s"
+		}
+	}`), 0644)
+	require.NoError(t, err)
+
+	viper.Reset()
+	viper.AddConfigPath(dir)
+	setting, err := NewSetting()
+	require.NoError(t, err)
+
+	assert.Equal(t, 110*time.Second, setting.HttpServer.ReadTimeout)
+	assert.Equal(t, 120*time.Second, setting.HttpServer.ReadHeaderTimeout)
+	assert.Equal(t, 130*time.Second, setting.HttpServer.WriteTimeout)
+	assert.Equal(t, 140*time.Second, setting.HttpServer.IdleTimeout)
 }
 
 func TestSplitCSV(t *testing.T) {

--- a/setting.json.example
+++ b/setting.json.example
@@ -36,5 +36,11 @@
 		"sessionTTL": "24h",
 		"adminSteamIds": [],
 		"steamApiKey": ""
+	},
+	"httpServer": {
+		"readTimeout": "120s",
+		"readHeaderTimeout": "120s",
+		"writeTimeout": "120s",
+		"idleTimeout": "120s"
 	}
 }

--- a/setting.json.example
+++ b/setting.json.example
@@ -39,7 +39,7 @@
 	},
 	"httpServer": {
 		"readTimeout": "120s",
-		"readHeaderTimeout": "120s",
+		"readHeaderTimeout": "30s",
 		"writeTimeout": "120s",
 		"idleTimeout": "120s"
 	}


### PR DESCRIPTION
## Summary

Add configurable settings for HTTP server timouts.  
Changed default timeouts to 120 seconds.  
All settings can be configurated by both environment variables and setting file.  

## How to test

1. Set `OCAP_HTTPSERVER_READTIMEOUT` to `1s`
2. Via admin panel upload some large map archive
3. Request must be failed

## Checklist

- [x] `go test ./...` passes
- [x] No breaking changes (or documented below)
