### PR TITLE
refactor: drop viper #761 BindEnv workaround

### DIFF
--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -84,6 +84,7 @@ func NewSetting() (setting Setting, err error) {
 
 	viper.SetDefault("listen", "127.0.0.1:5000")
 	viper.SetDefault("prefixURL", "")
+	viper.SetDefault("secret", "")
 	viper.SetDefault("db", "data.db")
 	viper.SetDefault("markers", "assets/markers")
 	viper.SetDefault("ammo", "assets/ammo")
@@ -93,7 +94,12 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("static", "")
 	viper.SetDefault("logger", false)
 	viper.SetDefault("customize.enabled", false)
+	viper.SetDefault("customize.websiteURL", "")
+	viper.SetDefault("customize.websiteLogo", "")
 	viper.SetDefault("customize.websiteLogoSize", "32px")
+	viper.SetDefault("customize.disableKillCount", false)
+	viper.SetDefault("customize.headerTitle", "")
+	viper.SetDefault("customize.headerSubtitle", "")
 	viper.SetDefault("conversion.enabled", false)
 	viper.SetDefault("conversion.interval", "5m")
 	viper.SetDefault("conversion.batchSize", 1)
@@ -111,49 +117,6 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("httpServer.readHeaderTimeout", "30s")
 	viper.SetDefault("httpServer.writeTimeout", "120s")
 	viper.SetDefault("httpServer.idleTimeout", "120s")
-
-	// workaround for https://github.com/spf13/viper/issues/761
-	envKeys := []string{
-		"listen",
-		"prefixURL",
-		"secret",
-		"db",
-		"markers",
-		"ammo",
-		"fonts",
-		"maps",
-		"data",
-		"static",
-		"customize.enabled",
-		"customize.websiteurl",
-		"customize.websitelogo",
-		"customize.websitelogosize",
-		"customize.disableKillCount",
-		"customize.headertitle",
-		"customize.headersubtitle",
-		"conversion.enabled",
-		"conversion.interval",
-		"conversion.batchSize",
-		"conversion.chunkSize",
-		"conversion.retryFailed",
-		"streaming.enabled",
-		"streaming.pingInterval",
-		"streaming.pingTimeout",
-		"auth.sessionTTL",
-		"auth.adminSteamIds",
-		"auth.steamApiKey",
-		"httpServer.readTimeout",
-		"httpServer.readHeaderTimeout",
-		"httpServer.writeTimeout",
-		"httpServer.idleTimeout",
-	}
-
-	for _, key := range envKeys {
-		env := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
-		if err = viper.BindEnv(key, env); err != nil {
-			return
-		}
-	}
 
 	if err = viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/internal/server/setting_test.go
+++ b/internal/server/setting_test.go
@@ -381,11 +381,11 @@ func TestNewSetting_EnvVars(t *testing.T) {
 		viper.AddConfigPath(dir)
 
 		os.Setenv("OCAP_SECRET", "env-secret")
-		os.Setenv("CONVERSION_ENABLED", "true")
-		os.Setenv("CONVERSION_CHUNKSIZE", "600")
+		os.Setenv("OCAP_CONVERSION_ENABLED", "true")
+		os.Setenv("OCAP_CONVERSION_CHUNKSIZE", "600")
 		defer os.Unsetenv("OCAP_SECRET")
-		defer os.Unsetenv("CONVERSION_ENABLED")
-		defer os.Unsetenv("CONVERSION_CHUNKSIZE")
+		defer os.Unsetenv("OCAP_CONVERSION_ENABLED")
+		defer os.Unsetenv("OCAP_CONVERSION_CHUNKSIZE")
 
 		setting, err := NewSetting()
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- viper [#761](https://github.com/spf13/viper/issues/761) was closed in Dec 2023, and viper v1.21.0 (already in `go.mod`) resolves env vars via `AutomaticEnv()` during `Unmarshal` as long as the key has a `SetDefault`. The explicit `BindEnv` loop is no longer needed.
- Drop the 35-entry `envKeys` slice + loop, add empty defaults for the six previously-unbound keys (`secret`, `customize.websiteURL`, `customize.websiteLogo`, `customize.disableKillCount`, `customize.headerTitle`, `customize.headerSubtitle`) so they continue to resolve from env.
- Behavior change: the removed loop accidentally bound env names without the `OCAP_` prefix (e.g. `CONVERSION_ENABLED`). Only the documented `OCAP_`-prefixed names are accepted now, matching `SetEnvPrefix("ocap")` and `CLAUDE.md`. The affected `nested env vars with underscore` test was updated accordingly.

## Test plan
- [x] `go test ./internal/server/...` passes
- [x] `go build ./...` clean
- [ ] Manual: confirm `OCAP_SECRET`, `OCAP_CUSTOMIZE_WEBSITEURL`, `OCAP_CONVERSION_ENABLED`, etc. still take effect at runtime