### PR TITLE
fix: swagger ui missing openapi.json

### DIFF
--- a/internal/server/openapi_ui.go
+++ b/internal/server/openapi_ui.go
@@ -8,7 +8,7 @@ import (
 // OpenAPIUIHandler returns an http.Handler that serves Scalar API reference
 // with native dark mode. The specURL from fuego is absolute (e.g. "/swagger/openapi.json")
 // but we use a relative URL so it resolves correctly behind a reverse proxy path prefix.
-func OpenAPIUIHandler(_ string) http.Handler {
+func OpenAPIUIHandler(openapiPath string) http.Handler {
 	const page = `<!doctype html>
 <html lang="en">
 <head>
@@ -17,7 +17,7 @@ func OpenAPIUIHandler(_ string) http.Handler {
 	<title>OCAP2 Web API</title>
 </head>
 <body>
-	<script id="api-reference" data-url="/swagger/openapi.json" data-configuration='{"darkMode":true,"showDeveloperTools":"never"}'></script>
+	<script id="api-reference" data-url="openapi.json" data-configuration='{"darkMode":true,"showDeveloperTools":"never"}'></script>
 	<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
 </body>
 </html>`

--- a/internal/server/openapi_ui.go
+++ b/internal/server/openapi_ui.go
@@ -17,7 +17,7 @@ func OpenAPIUIHandler(_ string) http.Handler {
 	<title>OCAP2 Web API</title>
 </head>
 <body>
-	<script id="api-reference" data-url="swagger/openapi.json" data-configuration='{"darkMode":true,"showDeveloperTools":"never"}'></script>
+	<script id="api-reference" data-url="/swagger/openapi.json" data-configuration='{"darkMode":true,"showDeveloperTools":"never"}'></script>
 	<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
 </body>
 </html>`

--- a/internal/server/openapi_ui.go
+++ b/internal/server/openapi_ui.go
@@ -8,7 +8,7 @@ import (
 // OpenAPIUIHandler returns an http.Handler that serves Scalar API reference
 // with native dark mode. The specURL from fuego is absolute (e.g. "/swagger/openapi.json")
 // but we use a relative URL so it resolves correctly behind a reverse proxy path prefix.
-func OpenAPIUIHandler(openapiPath string) http.Handler {
+func OpenAPIUIHandler(_ string) http.Handler {
 	const page = `<!doctype html>
 <html lang="en">
 <head>

--- a/internal/server/openapi_ui_test.go
+++ b/internal/server/openapi_ui_test.go
@@ -20,7 +20,7 @@ func TestOpenAPIUIHandler(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", rec.Header().Get("Content-Type"))
 
 	body := rec.Body.String()
-	assert.Contains(t, body, `data-url="swagger/openapi.json"`, "should use relative spec URL")
+	assert.Contains(t, body, `data-url="openapi.json"`, "should use relative spec URL")
 	assert.NotContains(t, body, "/ignored/absolute/path", "should not use absolute spec URL")
 	assert.Contains(t, body, `"darkMode":true`, "should enable dark mode")
 	assert.Contains(t, body, "OCAP2 Web API", "should have the page title")


### PR DESCRIPTION
## Summary

Fix path to openapi.json.  
Old path was relative to Swagger UI page, so script tried to fetch `/swagger/swagger/openapi.json` instead of `/swagger/openapi.json`

## How to test

Go to `<your-app>/swagger` and check network activities for `openapi.json` request

