### PR TITLE
fix: make deleted units count as dead

### DIFF
--- a/ui/src/pages/recording-playback/__tests__/UnitsTab.test.tsx
+++ b/ui/src/pages/recording-playback/__tests__/UnitsTab.test.tsx
@@ -227,6 +227,50 @@ describe("UnitsTab", () => {
     expect(twos.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("counts deleted units as dead and styles them", () => {
+    const { engine, renderer } = createTestEngine();
+    engine.loadRecording(
+      makeManifest([
+        unitDef({
+          id: 1,
+          name: "Alive Unit",
+          side: "WEST",
+          groupName: "Alpha",
+          role: "Grenadier",
+          positions: [
+            { position: [100, 200], direction: 0, alive: 1 },
+            { position: [100, 200], direction: 0, alive: 1 },
+          ],
+        }),
+        unitDef({
+          id: 2,
+          name: "Deleted Unit",
+          side: "WEST",
+          groupName: "Alpha",
+          endFrame: 1,
+          role: "Autorifleman",
+          positions: [{ position: [100, 200], direction: 0, alive: 1 }],
+        }),
+      ]),
+    );
+
+    // Advance to frame 1 so snapshots are populated
+    engine.seekTo(1);
+
+    render(() => (
+      <TestProviders engine={engine} renderer={renderer}>
+        <UnitsTab />
+      </TestProviders>
+    ));
+
+    // Deleted unit counts as dead: alive=1, total=2
+    expect(screen.getByText("1")).toBeTruthy(); // alive count in group header
+
+    // Deleted unit row must have the dead styling
+    const deletedRow = screen.getByText("Deleted Unit").closest("button");
+    expect(deletedRow?.className).toMatch(/unitRowDead/);
+  });
+
   it("only renders populated side tabs when multiple sides have units", () => {
     const { engine, renderer } = createTestEngine();
     engine.loadRecording(

--- a/ui/src/pages/recording-playback/components/UnitsTab.tsx
+++ b/ui/src/pages/recording-playback/components/UnitsTab.tsx
@@ -71,7 +71,7 @@ export function UnitsTab(props: UnitsTabProps): JSX.Element {
 
   const isAlive = (unitId: number): boolean => {
     const snap = engine.entitySnapshots().get(unitId);
-    return snap ? !!snap.alive : true;
+    return snap ? !!snap.alive : false;
   };
 
   // Frame-aware kill counts


### PR DESCRIPTION
## Summary

Make units that do not exist on the current frame be considered dead.  
Especially useful for missions where AI units are removed after a while if no player takes control.

## How to test

Check recording where units were deleted in-game.  
Example of this kind of recording:  
https://replays.vtg.in.ua/recording/2485/mVTG_Kontrakt_40_v01_20260502_225739  
Blue side, Alpha 1-3.  
The whole group was deleted at 03:00

## Checklist

- [x] `cd ui && npm test` passes
- [x] No breaking changes
