### PR TITLE
fix: missing query params in openapi specs

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/OCAP2/web/internal/maptool"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-fuego/fuego"
-	"github.com/go-fuego/fuego/option"
 	"github.com/yohcop/openid-go"
 )
 
@@ -145,12 +144,7 @@ func NewHandler(
 	fuego.Get(g, "/api/version", hdlr.GetVersion, fuego.OptionTags("Health"))
 
 	// Recordings (public read)
-	fuego.Get(g, "/api/v1/operations", hdlr.GetOperations, fuego.OptionTags("Recordings"),
-		option.Query("name", "Return only records matching the specified name (case-insensitive)"),
-		option.Query("older", "Return only records created before the specified date (YYYY-MM-DD)"),
-		option.Query("newer", "Return only records created after the specified date (YYYY-MM-DD)"),
-		option.Query("tag", "Return only records matching the specified tag (case-insensitive)"),
-	)
+	fuego.Get(g, "/api/v1/operations", hdlr.GetOperations, fuego.OptionTags("Recordings"))
 	fuego.Get(g, "/api/v1/operations/{id}", hdlr.GetOperation, fuego.OptionTags("Recordings"))
 	fuego.Get(g, "/api/v1/operations/{id}/marker-blacklist", hdlr.GetMarkerBlacklist, fuego.OptionTags("Recordings"))
 	fuego.PostStd(g, "/api/v1/operations/add", hdlr.StoreOperation, fuego.OptionTags("Recordings"))
@@ -220,7 +214,7 @@ func (*Handler) cacheControl(duration time.Duration) func(http.Handler) http.Han
 	}
 }
 
-func (h *Handler) GetOperations(c ContextNoBody) ([]Operation, error) {
+func (h *Handler) GetOperations(c fuego.Context[any, Filter]) ([]Operation, error) {
 	ctx := c.Context()
 	filter := Filter{
 		Name:  c.QueryParam("name"),

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -3,13 +3,13 @@ package server
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log/slog"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,6 +23,7 @@ import (
 	"github.com/OCAP2/web/internal/maptool"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
 	"github.com/yohcop/openid-go"
 )
 
@@ -59,8 +60,8 @@ type Handler struct {
 	repoAmmo          *RepoAmmo
 	setting           Setting
 	jwt               *JWTManager
-	conversionTrigger ConversionTrigger  // optional, nil if conversion disabled
-	staticFS          fs.FS              // optional, nil disables static file serving
+	conversionTrigger ConversionTrigger   // optional, nil if conversion disabled
+	staticFS          fs.FS               // optional, nil disables static file serving
 	maptoolMgr        *maptool.JobManager // optional, nil if maptool disabled
 	maptoolCfg        *maptoolConfig      // optional, nil if maptool disabled
 	openIDVerifier    openIDVerifier
@@ -144,7 +145,12 @@ func NewHandler(
 	fuego.Get(g, "/api/version", hdlr.GetVersion, fuego.OptionTags("Health"))
 
 	// Recordings (public read)
-	fuego.Get(g, "/api/v1/operations", hdlr.GetOperations, fuego.OptionTags("Recordings"))
+	fuego.Get(g, "/api/v1/operations", hdlr.GetOperations, fuego.OptionTags("Recordings"),
+		option.Query("name", "Return only records matching the specified name (case-insensitive)"),
+		option.Query("older", "Return only records created before the specified date (YYYY-MM-DD)"),
+		option.Query("newer", "Return only records created after the specified date (YYYY-MM-DD)"),
+		option.Query("tag", "Return only records matching the specified tag (case-insensitive)"),
+	)
 	fuego.Get(g, "/api/v1/operations/{id}", hdlr.GetOperation, fuego.OptionTags("Recordings"))
 	fuego.Get(g, "/api/v1/operations/{id}/marker-blacklist", hdlr.GetMarkerBlacklist, fuego.OptionTags("Recordings"))
 	fuego.PostStd(g, "/api/v1/operations/add", hdlr.StoreOperation, fuego.OptionTags("Recordings"))

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -84,7 +84,7 @@ func TestGetOperations(t *testing.T) {
 	}
 
 	t.Run("get all operations", func(t *testing.T) {
-		mockCtx := fuego.NewMockContextNoBody()
+		mockCtx := fuego.NewMockContext[any](nil, Filter{})
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/operations", nil)
 		mockCtx.SetRequest(req)
 
@@ -94,7 +94,7 @@ func TestGetOperations(t *testing.T) {
 	})
 
 	t.Run("filter by name", func(t *testing.T) {
-		mockCtx := fuego.NewMockContextNoBody()
+		mockCtx := fuego.NewMockContext[any](nil, Filter{})
 		mockCtx.SetQueryParam("name", "Alpha")
 
 		result, err := hdlr.GetOperations(mockCtx)
@@ -104,7 +104,7 @@ func TestGetOperations(t *testing.T) {
 	})
 
 	t.Run("filter by tag", func(t *testing.T) {
-		mockCtx := fuego.NewMockContextNoBody()
+		mockCtx := fuego.NewMockContext[any](nil, Filter{})
 		mockCtx.SetQueryParam("tag", "tvt")
 
 		result, err := hdlr.GetOperations(mockCtx)
@@ -114,7 +114,7 @@ func TestGetOperations(t *testing.T) {
 	})
 
 	t.Run("filter by date range", func(t *testing.T) {
-		mockCtx := fuego.NewMockContextNoBody()
+		mockCtx := fuego.NewMockContext[any](nil, Filter{})
 		mockCtx.SetQueryParam("newer", "2026-01-18")
 		mockCtx.SetQueryParam("older", "2026-01-25")
 
@@ -1500,7 +1500,7 @@ func TestGetOperations_Success(t *testing.T) {
 
 	hdlr := Handler{repoOperation: repo}
 
-	mockCtx := fuego.NewMockContextNoBody()
+	mockCtx := fuego.NewMockContext[any](nil, Filter{})
 	mockCtx.SetQueryParam("name", "Alpha")
 	mockCtx.SetQueryParam("tag", "coop")
 
@@ -1528,7 +1528,7 @@ func TestGetOperations_WithFilters(t *testing.T) {
 
 	hdlr := Handler{repoOperation: repo}
 
-	mockCtx := fuego.NewMockContextNoBody()
+	mockCtx := fuego.NewMockContext[any](nil, Filter{})
 	mockCtx.SetQueryParam("older", "2026-01-15")
 	mockCtx.SetQueryParam("newer", "2026-01-01")
 
@@ -1749,7 +1749,7 @@ func TestGetOperations_BindError(t *testing.T) {
 	// Test the Select error path using closed DB
 	repo.db.Close()
 
-	mockCtx := fuego.NewMockContextNoBody()
+	mockCtx := fuego.NewMockContext[any](nil, Filter{})
 	_, err = h.GetOperations(mockCtx)
 	assert.Error(t, err) // Should return the DB error
 }
@@ -2365,4 +2365,3 @@ func TestStoreOperation_EmptyFile(t *testing.T) {
 	h.StoreOperation(rec, req)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
-

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"testing"
 
-	pbv1 "github.com/OCAP2/web/pkg/schemas/protobuf/v1"
 	"github.com/OCAP2/web/internal/storage"
+	pbv1 "github.com/OCAP2/web/pkg/schemas/protobuf/v1"
 	"github.com/go-fuego/fuego"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -338,7 +338,7 @@ func TestIntegration_UploadWithoutConversion(t *testing.T) {
 
 	// Step 2: Query operations API and verify the operation is completed
 	t.Run("QueryShowsCompleted", func(t *testing.T) {
-		mockCtx := fuego.NewMockContextNoBody()
+		mockCtx := fuego.NewMockContext[any](nil, Filter{})
 
 		ops, err := hdlr.GetOperations(mockCtx)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

Specify query parameters in the `GET /api/v1/operations` method OpenAPI specification to prevent next warnings to be logged:

```
{"time":"...","level":"WARN","msg":"query parameter not expected in OpenAPI spec","param":"name","expected_one_of":["Accept"]}
{"time":"...","level":"WARN","msg":"query parameter not expected in OpenAPI spec","param":"older","expected_one_of":["Accept"]}
{"time":"...","level":"WARN","msg":"query parameter not expected in OpenAPI spec","param":"newer","expected_one_of":["Accept"]}
{"time":"...","level":"WARN","msg":"query parameter not expected in OpenAPI spec","param":"tag","expected_one_of":["Accept"]}
```

## How to test

A. See logs  
B. Check Swagger UI

## Checklist

- [x] `go test ./...` passes
- [x] No breaking changes (or documented below)
