### PR TITLE
feat: link swagger ui from admin top bar

### DIFF
--- a/ui/src/components/Icons.tsx
+++ b/ui/src/components/Icons.tsx
@@ -518,3 +518,10 @@ export const BracketOutIcon = (p: IconProps): JSX.Element => (
     <polyline points="16 4 20 4 20 20 16 20" />
   </svg>
 );
+
+export const BookOpenIcon = (p: IconProps): JSX.Element => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width={s(p.size)} height={s(p.size)}>
+    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+  </svg>
+);

--- a/ui/src/i18n/locales.ts
+++ b/ui/src/i18n/locales.ts
@@ -1450,6 +1450,16 @@ export const translations: Record<string, Record<Locale, string>> = {
     fi: "Tallenna muutokset",
     uk: "Зберегти зміни",
   },
+  api_docs: {
+    en: "API Documentation",
+    ru: "Документация API",
+    de: "API-Dokumentation",
+    cs: "Dokumentace API",
+    it: "Documentazione API",
+    fr: "Documentation de l'API",
+    fi: "API-dokumentaatio",
+    uk: "Документація API",
+  },
   upload_recording: {
     en: "Upload Recording",
     ru: "Загрузить запись",

--- a/ui/src/pages/recording-selector/RecordingSelector.tsx
+++ b/ui/src/pages/recording-selector/RecordingSelector.tsx
@@ -341,7 +341,7 @@ export function RecordingSelector(): JSX.Element {
                 <Show when={isAdmin()}>
                   <a
                     class={styles.adminIconButton}
-                    href={`${basePath}swagger`}
+                    href={`${basePath}swagger/`}
                     target="_blank"
                     rel="noopener noreferrer"
                     title={t("api_docs")}

--- a/ui/src/pages/recording-selector/RecordingSelector.tsx
+++ b/ui/src/pages/recording-selector/RecordingSelector.tsx
@@ -9,7 +9,7 @@ import { useCustomize } from "../../hooks/useCustomize";
 import { useAuth } from "../../hooks/useAuth";
 import { LOCALES } from "../../i18n/i18n";
 import { LOCALE_LABELS } from "./constants";
-import { GlobeIcon, UsersIcon, CrosshairIcon, ChevronDownIcon, UploadIcon, SearchIcon, TagIcon, MapIcon, XIcon, GitHubIcon, ExternalLinkIcon, HeartIcon, AlertTriangleIcon } from "../../components/Icons";
+import { GlobeIcon, UsersIcon, CrosshairIcon, ChevronDownIcon, UploadIcon, SearchIcon, TagIcon, MapIcon, XIcon, GitHubIcon, ExternalLinkIcon, HeartIcon, AlertTriangleIcon, BookOpenIcon } from "../../components/Icons";
 import { AuthBadge } from "../../components/AuthBadge";
 import { getMapColor, isRecordingReady, stripRecordingExtension } from "./helpers";
 import { StatPill, TagBadge, SortHeader } from "./components";
@@ -339,6 +339,15 @@ export function RecordingSelector(): JSX.Element {
               <div class={styles.adminArea}>
                 <AuthBadge />
                 <Show when={isAdmin()}>
+                  <a
+                    class={styles.adminIconButton}
+                    href={`${basePath}swagger`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={t("api_docs")}
+                  >
+                    <BookOpenIcon />
+                  </a>
                   <Show when={mapToolEnabled()}>
                     <button
                       class={styles.adminIconButton}


### PR DESCRIPTION
## Summary
- Adds a BookOpenIcon link to `/swagger` in the recording selector top bar, visible only to admins
- Discoverability: API docs were a hidden 2.1.0 feature; this surfaces them where someone managing recordings would look

## Test plan
- [ ] Log in as admin → book icon appears next to Map Manager / Upload, opens Swagger UI in new tab
- [ ] Log in as non-admin (or anonymous) → icon hidden
- [ ] Tooltip localized across all 8 locales