### PR TITLE
fix(ui): size marker smoothing tween to actual frame interval

### DIFF
--- a/ui/src/pages/recording-playback/useRenderBridge.ts
+++ b/ui/src/pages/recording-playback/useRenderBridge.ts
@@ -132,11 +132,15 @@ export function useRenderBridge(
     engine.unfollowEntity();
   });
 
-  // Smoothing: enable CSS transitions on markers during playback
+  // Smoothing: enable sub-frame interpolation during playback. The interval
+  // passed is the wall-clock gap between two position updates so the renderer
+  // can size its tween to complete in exactly one frame interval.
   createEffect(() => {
     const playing = engine.isPlaying();
     const speed = engine.playbackSpeed();
-    renderer.setSmoothingEnabled(playing, speed);
+    const captureDelayMs = engine.captureDelayMs();
+    const frameIntervalSec = speed > 0 ? captureDelayMs / 1000 / speed : 1;
+    renderer.setSmoothingEnabled(playing, frameIntervalSec);
   });
 
   // Side panel visibility → CSS custom property

--- a/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
+++ b/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
@@ -313,23 +313,23 @@ describe("EntityCanvasLayer", () => {
       return (layer as any).interpDurationSec;
     }
 
-    it("sets interpDurationSec to 1/speed (frame interval)", () => {
+    it("stores the supplied frame interval as the interpolation duration", () => {
       layer.setSmoothingEnabled(true, 1);
       expect(getInterpDuration()).toBeCloseTo(1.0);
 
-      layer.setSmoothingEnabled(true, 2);
+      layer.setSmoothingEnabled(true, 0.5);
       expect(getInterpDuration()).toBeCloseTo(0.5);
 
-      layer.setSmoothingEnabled(true, 5);
+      layer.setSmoothingEnabled(true, 0.2);
       expect(getInterpDuration()).toBeCloseTo(0.2);
 
-      layer.setSmoothingEnabled(true, 10);
+      layer.setSmoothingEnabled(true, 0.1);
       expect(getInterpDuration()).toBeCloseTo(0.1);
     });
 
-    it("entities reach target within one frame interval at high speed", () => {
+    it("entities reach target within one frame interval", () => {
       layer.addEntity(1, DEFAULT_OPTS);
-      layer.setSmoothingEnabled(true, 10);
+      layer.setSmoothingEnabled(true, 0.1);
       const interpDur = getInterpDuration(); // 0.1s
 
       // Move to new position — starts interpolation
@@ -343,25 +343,24 @@ describe("EntityCanvasLayer", () => {
       expect(progress).toBe(1);
     });
 
-    it("does not exceed 1s duration for fractional speeds", () => {
-      layer.setSmoothingEnabled(true, 0.5);
-      // speed 0.5 → 1/0.5 = 2s, but the guard caps at 1/speed
-      // which is correct: at 0.5x, frames come every 2s
+    it("respects long frame intervals (slow capture rate or fractional speed)", () => {
+      // E.g. captureDelayMs=1000, speed=0.5 → 2s interval
+      layer.setSmoothingEnabled(true, 2.0);
       expect(getInterpDuration()).toBeCloseTo(2.0);
     });
 
-    it("handles edge case of speed 0 without division error", () => {
+    it("falls back to 1s duration when interval is zero", () => {
       layer.setSmoothingEnabled(true, 0);
       expect(getInterpDuration()).toBe(1);
       expect(Number.isFinite(getInterpDuration())).toBe(true);
     });
 
-    it("preserves duration when speed is not provided", () => {
-      layer.setSmoothingEnabled(true, 4);
+    it("preserves duration when interval is not provided", () => {
+      layer.setSmoothingEnabled(true, 0.25);
       const dur = getInterpDuration();
       expect(dur).toBeCloseTo(0.25);
 
-      // Toggle smoothing without changing speed
+      // Toggle smoothing without changing interval
       layer.setSmoothingEnabled(false);
       expect(getInterpDuration()).toBeCloseTo(0.25); // unchanged
     });
@@ -835,7 +834,7 @@ describe("EntityCanvasLayer — render paths", () => {
 
   it("clamps interpolation progress to 1", () => {
     layer.addEntity(1, DEFAULT_OPTS);
-    layer.setSmoothingEnabled(true, 10); // 0.1s duration
+    layer.setSmoothingEnabled(true, 0.1); // 0.1s duration
     layer.updateEntity(1, makeState({ position: [1010, 2010] }));
     render(1.0); // well past 0.1s
     expect(getEntity(1).interpProgress).toBe(1);

--- a/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
+++ b/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
@@ -1063,6 +1063,76 @@ describe("EntityCanvasLayer — render paths", () => {
     expect(p.interpProgress).toBeGreaterThan(0);
   });
 
+  it("produces constant-velocity projectile motion when interval matches tween duration", () => {
+    // Simulates the bridge passing frameIntervalSec = captureDelayMs/1000/speed.
+    // For captureDelay 0.5s @ 1× speed, interval is 0.5s — tween must complete
+    // within that window so each segment advances by the full keyframe step.
+    const intervalSec = 0.5;
+    layer.setSmoothingEnabled(true, intervalSec);
+    layer.addProjectile(1, {
+      iconUrl: "http://example.com/grenade.png",
+      iconSize: [35, 35],
+    });
+
+    // Snap onto first keyframe (distance from origin triggers snap).
+    layer.updateProjectile(1, { position: [1000, 1000], direction: 0, alpha: 1 });
+
+    // Drive 4 ticks, each separated by exactly `intervalSec` of render time,
+    // with the shell advancing 30m per tick along x. Capture displayed x at
+    // the moment of each tick (right after updateProjectile, before any
+    // further rAF advances it). Use one full-interval render() per tick so
+    // interpProgress reaches exactly 1.0 (rAF granularity is mocked anyway).
+    const step = 30;
+    const displayedAtTick: number[] = [];
+    for (let tick = 1; tick <= 4; tick++) {
+      render(intervalSec);
+      const target = 1000 + tick * step;
+      layer.updateProjectile(1, { position: [target, 1000], direction: 0, alpha: 1 });
+      displayedAtTick.push((layer as any).projectiles.get(1).prevX);
+    }
+
+    // With interval == interpDuration, each tween fully reaches its target
+    // before the next tick — displayed position advances by `step` every
+    // tick. Velocity is constant: no acceleration profile, no kinks.
+    expect(displayedAtTick[1] - displayedAtTick[0]).toBeCloseTo(step, 5);
+    expect(displayedAtTick[2] - displayedAtTick[1]).toBeCloseTo(step, 5);
+    expect(displayedAtTick[3] - displayedAtTick[2]).toBeCloseTo(step, 5);
+  });
+
+  it("regression: oversized tween duration produces accelerating velocity (the old bug)", () => {
+    // Pre-fix behavior was to pass `1/speed` regardless of captureDelayMs.
+    // For captureDelay 0.5s the tween was 1s — twice the real interval —
+    // and each tick reset the tween at t≈0.5, leaving the shell lagging
+    // behind with a velocity that ramps up across ticks instead of being
+    // constant. This pins the old configuration so a future regression
+    // to it would be caught.
+    const intervalSec = 0.5;
+    const oversizedDuration = 1.0;
+    layer.setSmoothingEnabled(true, oversizedDuration);
+    layer.addProjectile(1, {
+      iconUrl: "http://example.com/grenade.png",
+      iconSize: [35, 35],
+    });
+
+    layer.updateProjectile(1, { position: [1000, 1000], direction: 0, alpha: 1 });
+
+    const step = 30;
+    const displayedAtTick: number[] = [];
+    for (let tick = 1; tick <= 3; tick++) {
+      render(intervalSec);
+      const target = 1000 + tick * step;
+      layer.updateProjectile(1, { position: [target, 1000], direction: 0, alpha: 1 });
+      displayedAtTick.push((layer as any).projectiles.get(1).prevX);
+    }
+
+    // First-tick advance is roughly half a step (tween only reached 50%).
+    const firstAdvance = displayedAtTick[1] - displayedAtTick[0];
+    // Second-tick advance is larger (catching up). Velocity not constant.
+    const secondAdvance = displayedAtTick[2] - displayedAtTick[1];
+    expect(firstAdvance).toBeLessThan(step * 0.7);
+    expect(secondAdvance).toBeGreaterThan(firstAdvance);
+  });
+
   it("uses cached projectile positions during zoom", () => {
     layer.addProjectile(1, {
       iconUrl: "http://example.com/grenade.png",

--- a/ui/src/renderers/leaflet/canvasLeafletRenderer.ts
+++ b/ui/src/renderers/leaflet/canvasLeafletRenderer.ts
@@ -117,9 +117,9 @@ export class CanvasLeafletRenderer extends LeafletRenderer {
     this.canvasLayer.removeEntity(unwrapHandle(handle));
   }
 
-  override setSmoothingEnabled(enabled: boolean, speed?: number): void {
+  override setSmoothingEnabled(enabled: boolean, frameIntervalSec?: number): void {
     // Guard: SolidJS effects may fire before init()
-    this.canvasLayer?.setSmoothingEnabled(enabled, speed);
+    this.canvasLayer?.setSmoothingEnabled(enabled, frameIntervalSec);
   }
 
   override dispose(): void {

--- a/ui/src/renderers/leaflet/entityCanvasLayer.ts
+++ b/ui/src/renderers/leaflet/entityCanvasLayer.ts
@@ -300,15 +300,14 @@ export class EntityCanvasLayer {
     this.entities.delete(id);
   }
 
-  setSmoothingEnabled(enabled: boolean, speed?: number): void {
+  setSmoothingEnabled(enabled: boolean, frameIntervalSec?: number): void {
     this.smoothing = enabled;
-    if (speed !== undefined) {
-      // Canvas interpolation must complete within the frame interval (1/speed)
-      // so entities reach their target before the next update arrives.
-      // The CSS renderer uses longer durations (getTransitionDuration) because
-      // CSS transitions redirect smoothly when interrupted, but canvas lerp
-      // accumulates visible lag if the duration exceeds the frame interval.
-      this.interpDurationSec = speed > 0 ? 1 / speed : 1;
+    if (frameIntervalSec !== undefined) {
+      // Canvas interpolation must complete within one frame interval so
+      // entities reach their target before the next update resets the tween.
+      // Otherwise visible lag accumulates and fast markers (e.g. projectiles)
+      // appear to step from keyframe to keyframe.
+      this.interpDurationSec = frameIntervalSec > 0 ? frameIntervalSec : 1;
     }
     // Don't snap on disable — entities freeze at their current interpolated
     // position. Seeking while paused snaps via updateEntity() instead.

--- a/ui/src/renderers/leaflet/leafletRenderer.ts
+++ b/ui/src/renderers/leaflet/leafletRenderer.ts
@@ -1230,7 +1230,7 @@ export class LeafletRenderer implements MapRenderer {
 
   // ==================== Settings ====================
 
-  setSmoothingEnabled(_enabled: boolean, _speed?: number): void {
+  setSmoothingEnabled(_enabled: boolean, _frameIntervalSec?: number): void {
     // no-op: CSS marker transitions removed
   }
 

--- a/ui/src/renderers/mockRenderer.ts
+++ b/ui/src/renderers/mockRenderer.ts
@@ -158,7 +158,7 @@ export class MockRenderer implements MapRenderer {
     this._setActiveStyleIndex(_index);
   }
 
-  setSmoothingEnabled(_enabled: boolean, _speed?: number): void {
+  setSmoothingEnabled(_enabled: boolean, _frameIntervalSec?: number): void {
     // no-op
   }
 

--- a/ui/src/renderers/renderer.interface.ts
+++ b/ui/src/renderers/renderer.interface.ts
@@ -57,7 +57,16 @@ export interface MapRenderer {
   setMapStyle(index: number): void;
 
   // Settings
-  setSmoothingEnabled(enabled: boolean, speed?: number): void;
+  /**
+   * Enable or disable sub-frame smoothing.
+   *
+   * `frameIntervalSec` is the wall-clock duration between consecutive
+   * position updates (i.e. `captureDelayMs / 1000 / playbackSpeed`). The
+   * renderer sizes its tween to that interval so positions reach their
+   * target before the next update arrives — otherwise lag accumulates and
+   * fast markers (e.g. projectiles) appear to step.
+   */
+  setSmoothingEnabled(enabled: boolean, frameIntervalSec?: number): void;
   nameDisplayMode: () => "players" | "all" | "none";
   setNameDisplayMode(mode: "players" | "all" | "none"): void;
 


### PR DESCRIPTION
## Summary
The canvas smoothing tween duration was hardcoded to `1/speed`, which silently assumes `captureDelayMs === 1000`. Recordings with a smaller capture delay (e.g. `captureDelay: 0.5`) had a tween duration twice the actual frame interval, so each `updateProjectile`/`updateEntity` reset the tween at `t ≈ 0.5`. This produced a velocity profile that ramps up across the first few ticks before settling — visible as kinks/jitter for fast markers, mostly invisible for slow units.

Change the renderer contract from `setSmoothingEnabled(enabled, speed)` to `setSmoothingEnabled(enabled, frameIntervalSec)`. The bridge owns the engine's capture rate and computes `captureDelayMs / 1000 / speed` before passing it down. The renderer no longer needs to assume anything about timing. Behavior is unchanged for recordings with the default 1s `captureDelay`.

## What this proves
- Behavior tests in `entityCanvasLayer.test.ts` drive a projectile through four ticks at a fixed interval and inspect the displayed position at each tick boundary:
  - **Post-fix:** advance is exactly `step` per tick — constant velocity.
  - **Pre-fix (regression pin):** first-tick advance is < `0.7 × step`, second is larger — accelerating velocity profile.
- The math claim is now executable, not a hand-wave.

## What this does NOT prove
- The original report described "frame by frame" updates on M109A6 HE shells. The math says the **pre-fix** code already produced *continuous* motion (with kinks and lag), not discrete teleports. So:
  - If the user's perception was kinks/jitter on fast markers — this fix addresses it.
  - If they were seeing literal teleports — the cause is elsewhere and this PR only addresses a related miscalibration.
- I could not visually verify against `C7M3_Blood_And_Roses_V4_20260509_210857.json` in a dev session before opening this PR.

The PR is defensible as **"tween duration was miscalibrated for non-default capture delays"** independent of the original symptom — that miscalibration is a real bug with a real visible effect.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/renderers src/playback src/pages/recording-playback` — 894 → 896 passing (two new tests)
- [ ] Visual verification: replay the C7M3 recording with this branch and observe a Pinky M109A6 HE shell. If still stepping → reopen the investigation; the bug is elsewhere.

## Files changed
- `ui/src/renderers/renderer.interface.ts` — contract + doc
- `ui/src/pages/recording-playback/useRenderBridge.ts` — bridge computes interval; effect re-fires on capture-rate changes too
- `ui/src/renderers/leaflet/entityCanvasLayer.ts` — store interval directly, comment matches behavior
- `ui/src/renderers/leaflet/canvasLeafletRenderer.ts`, `leafletRenderer.ts`, `mockRenderer.ts` — signatures
- `ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts` — interval-semantic cases + behavior tests