### PR TITLE
chore: bump go directive to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OCAP2/web
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/getkin/kin-openapi v0.135.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from `1.26.0` to `1.26.3`.
- Go 1.26.0 hits an internal compiler error (`tried to free an already free register`) when compiling `go-fuego/fuego` against `kin-openapi` v0.136+. Go 1.26.3 fixes it.
- Unblocks dependabot PR #426 (`kin-openapi` 0.135.0 → 0.138.0); after merging, comment `@dependabot rebase` on #426 to make CI pass.

## Test plan
- [x] `go build ./...` succeeds with Go 1.26.3 + kin-openapi v0.138.0 locally
- [x] `go test ./...` passes with Go 1.26.3 + kin-openapi v0.138.0 locally
- [ ] CI green on this PR