### PR TITLE
fix(ui): add space separator between EndMissionEvent side and message

### DIFF
--- a/ui/src/pages/recording-playback/components/EventsTab.tsx
+++ b/ui/src/pages/recording-playback/components/EventsTab.tsx
@@ -216,13 +216,13 @@ export function EventsTab(): JSX.Element {
                     ) : event instanceof EndMissionEvent ? (
                       <>
                         <span class={styles.eventNames}>
-                          <Show when={event.side}>
-                            <span style={{ color: sideColor(event.side) }}>
-                              {event.side}
-                            </span>
+                          <span style={{ color: sideColor(event.side) }}>
+                            {event.side}
+                          </span>
+                          <Show when={event.message}>
                             {" "}
+                            <span style={{ color: "var(--text-secondary)" }}>{event.message}</span>
                           </Show>
-                          <span style={{ color: "var(--text-secondary)" }}>{event.message}</span>
                         </span>
                         <span class={styles.eventMeta}>
                           <span class={styles.eventTime}>

--- a/ui/src/pages/recording-playback/components/EventsTab.tsx
+++ b/ui/src/pages/recording-playback/components/EventsTab.tsx
@@ -216,10 +216,12 @@ export function EventsTab(): JSX.Element {
                     ) : event instanceof EndMissionEvent ? (
                       <>
                         <span class={styles.eventNames}>
-                          <span style={{ color: sideColor(event.side) }}>
-                            {event.side}
-                          </span>
-                          {" "}
+                          <Show when={event.side}>
+                            <span style={{ color: sideColor(event.side) }}>
+                              {event.side}
+                            </span>
+                            {" "}
+                          </Show>
                           <span style={{ color: "var(--text-secondary)" }}>{event.message}</span>
                         </span>
                         <span class={styles.eventMeta}>

--- a/ui/src/pages/recording-playback/components/EventsTab.tsx
+++ b/ui/src/pages/recording-playback/components/EventsTab.tsx
@@ -219,6 +219,7 @@ export function EventsTab(): JSX.Element {
                           <span style={{ color: sideColor(event.side) }}>
                             {event.side}
                           </span>
+                          {" "}
                           <span style={{ color: "var(--text-secondary)" }}>{event.message}</span>
                         </span>
                         <span class={styles.eventMeta}>


### PR DESCRIPTION
## Summary

The `EndMissionEvent` row in the Events tab rendered the side label and the mission message in adjacent `<span>` elements with no whitespace between them, causing them to appear concatenated (e.g. `WESTMission ended`).

Added a `{" "}` text node between the two spans, matching the separator pattern already used for `HitKilledEvent` name tokens.

Before:
<img width="399" height="115" alt="image" src="https://github.com/user-attachments/assets/c1d8db22-e73d-426b-941f-358339bd5347" />

After:
<img width="387" height="98" alt="image" src="https://github.com/user-attachments/assets/f0b46605-0f80-40aa-a135-1a5c9a381849" />

## Test plan

- [x] Open a recording that contains an end-mission event — side label and message are visually separated by a space.
- [x] `cd ui && npx vitest run` — all 34 tests pass.

## Files

- `ui/src/pages/recording-playback/components/EventsTab.tsx` — one-line fix in `EndMissionEvent` render branch.