### PR TITLE
docs: clarify OCAP_AUTH_ADMINSTEAMIDS takes no brackets in env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Admin access uses Steam OpenID — no passwords. Admins authenticate via their S
 | Setting | Env Var | Description | Default |
 |---------|---------|-------------|---------|
 | `auth.sessionTTL` | `OCAP_AUTH_SESSIONTTL` | How long admin sessions last | `24h` |
-| `auth.adminSteamIds` | `OCAP_AUTH_ADMINSTEAMIDS` | Steam64 IDs authorized for admin access (comma-separated in env var) | `[]` |
+| `auth.adminSteamIds` | `OCAP_AUTH_ADMINSTEAMIDS` | Steam64 IDs authorized for admin access (comma-separated, no brackets, in env var) | `[]` |
 | `auth.steamApiKey` | `OCAP_AUTH_STEAMAPIKEY` | Steam Web API key for fetching display names and avatars ([get one here](https://steamcommunity.com/dev/apikey)) | `""` |
 
 The Steam API key is optional. Without it, the admin badge shows the raw Steam64 ID. With it, the admin's Steam profile picture and display name are shown.

--- a/egg-ocap2-web-pterodactyl.json
+++ b/egg-ocap2-web-pterodactyl.json
@@ -100,7 +100,7 @@
     },
     {
       "name": "Allowed Steam IDs",
-      "description": "Comma-separated list of Steam64 IDs authorized for admin login via Steam OpenID. Leave empty to disable Steam admin login.",
+      "description": "Comma-separated list of Steam64 IDs authorized for admin login via Steam OpenID, e.g. 76561198012345678,76561198087654321 (no brackets, no quotes). Leave empty to disable Steam admin login.",
       "env_variable": "OCAP_AUTH_ADMINSTEAMIDS",
       "default_value": "",
       "user_viewable": true,

--- a/egg-ocap2-web.json
+++ b/egg-ocap2-web.json
@@ -105,7 +105,7 @@
         },
         {
             "name": "Allowed Steam IDs",
-            "description": "Comma-separated list of Steam64 IDs authorized for admin login via Steam OpenID. Leave empty to disable Steam admin login.",
+            "description": "Comma-separated list of Steam64 IDs authorized for admin login via Steam OpenID, e.g. 76561198012345678,76561198087654321 (no brackets, no quotes). Leave empty to disable Steam admin login.",
             "env_variable": "OCAP_AUTH_ADMINSTEAMIDS",
             "default_value": "",
             "user_viewable": true,


### PR DESCRIPTION
## Why

A user set `OCAP_AUTH_ADMINSTEAMIDS=[id1,id2]` (JSON-array brackets) and was silently never recognized as admin. Since the viper #761 BindEnv workaround was removed, viper resolves the env var into the `[]string` field by splitting on commas only — it does **not** strip brackets. So `[id1,id2]` parses as `["[id1", "id2]"]` and `slices.Contains` never matches the real Steam ID. Removing the brackets (`id1,id2`) works.

## What

Documentation-only clarification (no behavior change):

- **README.md** — admin Steam IDs table cell now reads "comma-separated, **no brackets**, in env var".
- **egg-ocap2-web.json** / **egg-ocap2-web-pterodactyl.json** — the "Allowed Steam IDs" field description gains an inline example `76561198012345678,76561198087654321 (no brackets, no quotes)`, since the Pelican/Pterodactyl config UI is where the reporting user was.

The bracketed `["..."]` form remains correct for `setting.json` (JSON array).