### PR TITLE
fix: honor client-supplied date on recording upload

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -318,6 +318,16 @@ func (*Handler) GetHealthcheck(c ContextNoBody) (HealthResponse, error) {
 	return HealthResponse{Status: "ok"}, nil
 }
 
+// isValidOperationDate reports whether s is an acceptable operation date:
+// either a plain calendar date (YYYY-MM-DD) or a full RFC3339 timestamp.
+func isValidOperationDate(s string) bool {
+	if _, err := time.Parse("2006-01-02", s); err == nil {
+		return true
+	}
+	_, err := time.Parse(time.RFC3339, s)
+	return err == nil
+}
+
 func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
@@ -359,9 +369,14 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 
 	// Honor a client-supplied date (admin UI upload). The Arma addon does not
 	// send one, so fall back to the current date to preserve its behavior.
+	// Accept either a plain date (YYYY-MM-DD) or an RFC3339 timestamp (the
+	// admin UI sends the latter) and reject anything else to keep the column clean.
 	date := r.FormValue("date")
 	if date == "" {
 		date = time.Now().Format("2006-01-02")
+	} else if !isValidOperationDate(date) {
+		http.Error(w, "Invalid date format", http.StatusBadRequest)
+		return
 	}
 
 	op := Operation{

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -357,11 +357,18 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 	// directories. Mirror the cleanup performed by migration v11.
 	filename = decodeFilename(filename)
 
+	// Honor a client-supplied date (admin UI upload). The Arma addon does not
+	// send one, so fall back to the current date to preserve its behavior.
+	date := r.FormValue("date")
+	if date == "" {
+		date = time.Now().Format("2006-01-02")
+	}
+
 	op := Operation{
 		WorldName:   r.FormValue("worldName"),
 		MissionName: r.FormValue("missionName"),
 		Filename:    filename,
-		Date:        time.Now().Format("2006-01-02"),
+		Date:        date,
 		// Support old extension version tag or type
 		Tag: r.FormValue("tag") + r.FormValue("type"),
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -243,6 +243,67 @@ func TestStoreOperation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("uses client-supplied date", func(t *testing.T) {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		require.NoError(t, writer.WriteField("secret", "test-secret"))
+		require.NoError(t, writer.WriteField("worldName", "altis"))
+		require.NoError(t, writer.WriteField("missionName", "Dated Mission"))
+		require.NoError(t, writer.WriteField("missionDuration", "3600"))
+		require.NoError(t, writer.WriteField("filename", "dated_upload"))
+		require.NoError(t, writer.WriteField("date", "2022-02-21T00:00:00.000Z"))
+
+		fileWriter, err := writer.CreateFormFile("file", "dated_upload.json.gz")
+		require.NoError(t, err)
+		gw := gzip.NewWriter(fileWriter)
+		_, err = gw.Write([]byte(`{"test": "data"}`))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		require.NoError(t, writer.Close())
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/add", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+
+		hdlr.StoreOperation(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		op, err := repo.GetByFilename(context.Background(), "dated_upload")
+		require.NoError(t, err)
+		assert.Equal(t, "2022-02-21T00:00:00.000Z", op.Date)
+	})
+
+	t.Run("defaults to current date when omitted", func(t *testing.T) {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		require.NoError(t, writer.WriteField("secret", "test-secret"))
+		require.NoError(t, writer.WriteField("worldName", "altis"))
+		require.NoError(t, writer.WriteField("missionName", "Undated Mission"))
+		require.NoError(t, writer.WriteField("missionDuration", "3600"))
+		require.NoError(t, writer.WriteField("filename", "undated_upload"))
+
+		fileWriter, err := writer.CreateFormFile("file", "undated_upload.json.gz")
+		require.NoError(t, err)
+		gw := gzip.NewWriter(fileWriter)
+		_, err = gw.Write([]byte(`{"test": "data"}`))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		require.NoError(t, writer.Close())
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/add", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+
+		hdlr.StoreOperation(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		op, err := repo.GetByFilename(context.Background(), "undated_upload")
+		require.NoError(t, err)
+		assert.Equal(t, time.Now().Format("2006-01-02"), op.Date)
+	})
+
 	t.Run("wrong secret", func(t *testing.T) {
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -304,6 +304,33 @@ func TestStoreOperation(t *testing.T) {
 		assert.Equal(t, time.Now().Format("2006-01-02"), op.Date)
 	})
 
+	t.Run("rejects malformed date", func(t *testing.T) {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		require.NoError(t, writer.WriteField("secret", "test-secret"))
+		require.NoError(t, writer.WriteField("worldName", "altis"))
+		require.NoError(t, writer.WriteField("missionName", "Bad Date Mission"))
+		require.NoError(t, writer.WriteField("missionDuration", "3600"))
+		require.NoError(t, writer.WriteField("filename", "baddate_upload"))
+		require.NoError(t, writer.WriteField("date", "not-a-date"))
+
+		fileWriter, err := writer.CreateFormFile("file", "baddate_upload.json.gz")
+		require.NoError(t, err)
+		gw := gzip.NewWriter(fileWriter)
+		_, err = gw.Write([]byte(`{"test": "data"}`))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		require.NoError(t, writer.Close())
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/add", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+
+		hdlr.StoreOperation(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
 	t.Run("wrong secret", func(t *testing.T) {
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)

--- a/ui/src/pages/recording-selector/dialogs.tsx
+++ b/ui/src/pages/recording-selector/dialogs.tsx
@@ -102,6 +102,7 @@ const [date, setDate] = createSignal(isoToLocalInput(props.rec.date));
               <label class={styles.editLabel}>{t("date")}</label>
               <input
                 type="datetime-local"
+                step="1"
                 value={date()}
                 onInput={(e) => setDate(e.currentTarget.value)}
                 class={ui.input}
@@ -276,6 +277,7 @@ export function UploadDialog(props: {
             <label class={styles.editLabel}>{t("date")}</label>
             <input
               type="datetime-local"
+              step="1"
               value={date()}
               onInput={(e) => setDate(e.currentTarget.value)}
               class={ui.input}


### PR DESCRIPTION
## Problem

Two date-handling bugs in the recording selector, reported from the UI:

1. **Upload date is ignored.** Whatever date you pick in the *Upload Recording* dialog is silently replaced with today's date and time after upload.
2. **Inconsistent time precision.** The upload dialog's date picker offers `HH:MM:SS`, but the edit dialog only offers `HH:MM`.

## Root cause

- **Bug 1:** `StoreOperation` in `internal/server/handler.go` hardcoded `Date: time.Now().Format("2006-01-02")` and never read the `date` form field the admin UI sends. The edit (`PATCH`) path already respected the submitted date, which is why editing worked but uploading didn't.
- **Bug 2:** Both `datetime-local` inputs were identical with no `step` attribute. Browsers only render the seconds field when the value's seconds are non-zero. The upload picker defaults to `new Date()` (live seconds → seconds shown), while edit loads stored dates like `2026-02-03` that render as `…T00:00:00` (seconds = 00 → field hidden).

## Fix

- Read `r.FormValue("date")` on upload and use it when present, falling back to `time.Now()` only when absent — this preserves the Arma addon upload path, which sends no `date` field.
- Add `step="1"` to both the upload and edit `datetime-local` inputs so seconds precision is offered consistently.

## Notes

- Storing the client-supplied value as-is matches what the edit path already does. The `date` column already contains a mix of `YYYY-MM-DD` and full-ISO values; display (`formatDate`) and sort both parse either, so no migration is needed.

## Testing

- `go build ./internal/server/` — passes
- `npm run build` (UI) — passes