### PR TITLE
fix: enforce recording filename uniqueness to prevent data corruption

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -367,6 +367,14 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 	// directories. Mirror the cleanup performed by migration v11.
 	filename = decodeFilename(filename)
 
+	// Reject names that would resolve to the data directory or its parent — the
+	// filename is used directly in filepath.Join for both file writes and
+	// os.RemoveAll, so an empty/"."/".."/separator name could wipe the data dir.
+	if isInvalidStorageName(filename) {
+		http.Error(w, "Invalid filename", http.StatusBadRequest)
+		return
+	}
+
 	// Honor a client-supplied date (admin UI upload). The Arma addon does not
 	// send one, so fall back to the current date to preserve its behavior.
 	// Accept either a plain date (YYYY-MM-DD) or an RFC3339 timestamp (the
@@ -420,10 +428,11 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the new recording file BEFORE mutating any existing state. A
-	// malformed or failed upload (missing file part, disk error) must never
-	// destroy the recording it would replace. The .json.gz path is keyed by
-	// filename, so os.Create overwrites any previous source file in place.
+	// Write the new recording file BEFORE mutating any existing state, and write
+	// it to a temp file first. A malformed or interrupted upload (missing file
+	// part, disconnect mid-stream, disk error) must never truncate or destroy
+	// the recording it would replace — only the temp file is at risk until the
+	// upload fully succeeds.
 	form, _, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -440,35 +449,46 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	isGzipped := header[0] == 0x1f && header[1] == 0x8b
 
-	outFile, err := os.Create(filepath.Join(h.setting.Data, filename+".json.gz"))
+	finalPath := filepath.Join(h.setting.Data, filename+".json.gz")
+	tmpPath := finalPath + ".tmp"
+	tmpFile, err := os.Create(tmpPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer outFile.Close()
 
-	if isGzipped {
-		if _, err = io.Copy(outFile, br); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+	// Stream the upload into the temp file, gzipping on the fly if needed.
+	// Close the file before renaming so the data is flushed and the rename is
+	// valid on all platforms.
+	writeErr := func() error {
+		defer tmpFile.Close()
+		if isGzipped {
+			_, err := io.Copy(tmpFile, br)
+			return err
 		}
-	} else {
-		gw := gzip.NewWriter(outFile)
-		if _, err = io.Copy(gw, br); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+		gw := gzip.NewWriter(tmpFile)
+		if _, err := io.Copy(gw, br); err != nil {
+			return err
 		}
-		if err = gw.Close(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		return gw.Close()
+	}()
+	if writeErr != nil {
+		os.Remove(tmpPath)
+		http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+		return
 	}
 
-	// Replace semantics: the new file is now safely on disk. Store the row,
-	// atomically dropping any previous recording with the same filename (the
-	// filename is the unique on-disk storage key). Doing this only after a
-	// successful write — and atomically — ensures a malformed or failed upload
-	// can never destroy the recording it would replace.
+	// Atomically swap the new file into place. Only now is the previous file
+	// replaced; if anything above failed, the original is untouched.
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		os.Remove(tmpPath)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Replace semantics: the new file is now in place. Store the row, atomically
+	// dropping any previous recording with the same filename (the filename is
+	// the unique on-disk storage key).
 	if err = h.repoOperation.StoreReplacingByFilename(ctx, &op); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -420,11 +420,10 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = h.repoOperation.Store(ctx, &op); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
+	// Write the new recording file BEFORE mutating any existing state. A
+	// malformed or failed upload (missing file part, disk error) must never
+	// destroy the recording it would replace. The .json.gz path is keyed by
+	// filename, so os.Create overwrites any previous source file in place.
 	form, _, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -463,6 +462,24 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+	}
+
+	// Replace semantics: the new file is now safely on disk. Store the row,
+	// atomically dropping any previous recording with the same filename (the
+	// filename is the unique on-disk storage key). Doing this only after a
+	// successful write — and atomically — ensures a malformed or failed upload
+	// can never destroy the recording it would replace.
+	if err = h.repoOperation.StoreReplacingByFilename(ctx, &op); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Remove any stale protobuf directory from a previous conversion of this
+	// filename (a no-op for a brand-new upload). The new .json.gz was written
+	// above; conversion, if enabled, rebuilds the directory from it.
+	pbDir := filepath.Join(h.setting.Data, filename)
+	if err := os.RemoveAll(pbDir); err != nil {
+		slog.Warn("failed to remove stale protobuf directory", "path", pbDir, "error", err)
 	}
 
 	// Trigger conversion immediately if enabled (async, non-blocking).

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -367,9 +367,6 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 	// directories. Mirror the cleanup performed by migration v11.
 	filename = decodeFilename(filename)
 
-	// Reject names that would resolve to the data directory or its parent — the
-	// filename is used directly in filepath.Join for both file writes and
-	// os.RemoveAll, so an empty/"."/".."/separator name could wipe the data dir.
 	if isInvalidStorageName(filename) {
 		http.Error(w, "Invalid filename", http.StatusBadRequest)
 		return
@@ -428,11 +425,8 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the new recording file BEFORE mutating any existing state, and write
-	// it to a temp file first. A malformed or interrupted upload (missing file
-	// part, disconnect mid-stream, disk error) must never truncate or destroy
-	// the recording it would replace — only the temp file is at risk until the
-	// upload fully succeeds.
+	// Write to a temp file first so a malformed or interrupted upload can never
+	// truncate the recording it would replace.
 	form, _, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -457,9 +451,7 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stream the upload into the temp file, gzipping on the fly if needed.
-	// Close the file before renaming so the data is flushed and the rename is
-	// valid on all platforms.
+	// Close before renaming: flushes the data, and Windows can't rename an open file.
 	writeErr := func() error {
 		defer tmpFile.Close()
 		if isGzipped {
@@ -478,25 +470,19 @@ func (h *Handler) StoreOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Atomically swap the new file into place. Only now is the previous file
-	// replaced; if anything above failed, the original is untouched.
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		os.Remove(tmpPath)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Replace semantics: the new file is now in place. Store the row, atomically
-	// dropping any previous recording with the same filename (the filename is
-	// the unique on-disk storage key).
 	if err = h.repoOperation.StoreReplacingByFilename(ctx, &op); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Remove any stale protobuf directory from a previous conversion of this
-	// filename (a no-op for a brand-new upload). The new .json.gz was written
-	// above; conversion, if enabled, rebuilds the directory from it.
+	// Drop the stale protobuf directory from any previous conversion of this
+	// filename; conversion, if enabled, rebuilds it.
 	pbDir := filepath.Join(h.setting.Data, filename)
 	if err := os.RemoveAll(pbDir); err != nil {
 		slog.Warn("failed to remove stale protobuf directory", "path", pbDir, "error", err)

--- a/internal/server/handler_admin.go
+++ b/internal/server/handler_admin.go
@@ -216,6 +216,13 @@ func (h *Handler) DeleteOperation(c ContextNoBody) (any, error) {
 // `<filename>.json.gz` source file and the `<filename>/` protobuf directory.
 // Missing paths are not errors; failures are logged and ignored (best-effort).
 func removeRecordingArtifacts(dataDir, filename string) {
+	// Defense in depth: never let an empty/"."/".."/separator filename turn the
+	// RemoveAll below into a wipe of the entire data directory.
+	if isInvalidStorageName(filename) {
+		slog.Warn("refusing to remove recording artifacts for invalid filename", "filename", filename)
+		return
+	}
+
 	jsonGzPath := filepath.Join(dataDir, filename+".json.gz")
 	if err := os.Remove(jsonGzPath); err != nil && !os.IsNotExist(err) {
 		slog.Warn("failed to remove file", "path", jsonGzPath, "error", err)

--- a/internal/server/handler_admin.go
+++ b/internal/server/handler_admin.go
@@ -206,16 +206,23 @@ func (h *Handler) DeleteOperation(c ContextNoBody) (any, error) {
 	}
 
 	// Clean up files (best-effort, don't fail the request)
-	jsonGzPath := filepath.Join(h.setting.Data, op.Filename+".json.gz")
+	removeRecordingArtifacts(h.setting.Data, op.Filename)
+
+	c.SetStatus(http.StatusNoContent)
+	return nil, nil
+}
+
+// removeRecordingArtifacts removes a recording's on-disk data: the
+// `<filename>.json.gz` source file and the `<filename>/` protobuf directory.
+// Missing paths are not errors; failures are logged and ignored (best-effort).
+func removeRecordingArtifacts(dataDir, filename string) {
+	jsonGzPath := filepath.Join(dataDir, filename+".json.gz")
 	if err := os.Remove(jsonGzPath); err != nil && !os.IsNotExist(err) {
 		slog.Warn("failed to remove file", "path", jsonGzPath, "error", err)
 	}
 
-	pbDir := filepath.Join(h.setting.Data, op.Filename)
+	pbDir := filepath.Join(dataDir, filename)
 	if err := os.RemoveAll(pbDir); err != nil {
 		slog.Warn("failed to remove directory", "path", pbDir, "error", err)
 	}
-
-	c.SetStatus(http.StatusNoContent)
-	return nil, nil
 }

--- a/internal/server/handler_admin_test.go
+++ b/internal/server/handler_admin_test.go
@@ -855,3 +855,31 @@ func TestDeleteOperation_ReadOnlyFileCleanup(t *testing.T) {
 	_, err = os.Stat(jsonGzPath)
 	assert.NoError(t, err, "json.gz should still exist")
 }
+
+func TestRemoveRecordingArtifacts(t *testing.T) {
+	t.Run("removes json and protobuf dir", func(t *testing.T) {
+		dataDir := t.TempDir()
+		jsonGz := filepath.Join(dataDir, "rec.json.gz")
+		require.NoError(t, os.WriteFile(jsonGz, []byte("data"), 0644))
+		pbDir := filepath.Join(dataDir, "rec")
+		require.NoError(t, os.MkdirAll(filepath.Join(pbDir, "chunks"), 0755))
+
+		removeRecordingArtifacts(dataDir, "rec")
+
+		assert.NoFileExists(t, jsonGz)
+		assert.NoDirExists(t, pbDir)
+	})
+
+	t.Run("refuses unsafe filenames and leaves data dir intact", func(t *testing.T) {
+		for _, name := range []string{"", ".", "..", "/"} {
+			dataDir := t.TempDir()
+			canary := filepath.Join(dataDir, "canary.txt")
+			require.NoError(t, os.WriteFile(canary, []byte("keep"), 0644))
+
+			removeRecordingArtifacts(dataDir, name)
+
+			assert.FileExists(t, canary, "data dir must survive removeRecordingArtifacts(%q)", name)
+			assert.DirExists(t, dataDir)
+		}
+	})
+}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -435,6 +435,138 @@ func TestIntegration_UploadAndServeGzippedJSON(t *testing.T) {
 	})
 }
 
+// uploadJSONRecording builds and executes a multipart upload of a gzipped JSON
+// recording with the given filename via StoreOperation.
+func uploadJSONRecording(t *testing.T, hdlr *Handler, filename, missionName string) *httptest.ResponseRecorder {
+	t.Helper()
+	recording := map[string]interface{}{
+		"worldName":   "altis",
+		"missionName": missionName,
+		"endFrame":    5,
+		"entities":    []interface{}{},
+		"events":      []interface{}{},
+	}
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	require.NoError(t, json.NewEncoder(gw).Encode(recording))
+	require.NoError(t, gw.Close())
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	writer.WriteField("secret", "test-secret")
+	writer.WriteField("filename", filename)
+	writer.WriteField("worldName", "altis")
+	writer.WriteField("missionName", missionName)
+	writer.WriteField("missionDuration", "300")
+	part, err := writer.CreateFormFile("file", filename+".json.gz")
+	require.NoError(t, err)
+	_, err = io.Copy(part, &gzBuf)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/add", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	hdlr.StoreOperation(rec, req)
+	return rec
+}
+
+// TestIntegration_UploadSameFilenameReplaces verifies that re-uploading a
+// recording with an existing filename replaces the old one instead of creating
+// a duplicate row that shares (and corrupts) the same on-disk files. It also
+// asserts the stale protobuf directory from a prior conversion is removed.
+func TestIntegration_UploadSameFilenameReplaces(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	dataDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	repo, err := NewRepoOperation(dbPath)
+	require.NoError(t, err)
+	defer repo.db.Close()
+
+	hdlr := &Handler{
+		repoOperation: repo,
+		setting:       Setting{Data: dataDir, Secret: "test-secret"},
+	}
+
+	const filename = "shared_name"
+
+	// First upload.
+	require.Equal(t, http.StatusOK, uploadJSONRecording(t, hdlr, filename, "First").Code)
+
+	// Simulate a prior conversion having produced a protobuf directory with a
+	// stale chunk that must not survive the replacement.
+	chunksDir := filepath.Join(dataDir, filename, "chunks")
+	require.NoError(t, os.MkdirAll(chunksDir, 0755))
+	staleChunk := filepath.Join(chunksDir, "0099.pb")
+	require.NoError(t, os.WriteFile(staleChunk, []byte("stale"), 0644))
+
+	// Second upload with the SAME filename.
+	require.Equal(t, http.StatusOK, uploadJSONRecording(t, hdlr, filename, "Second").Code)
+
+	ctx := context.Background()
+	ops, err := repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "re-upload must replace, not duplicate")
+	assert.Equal(t, "Second", ops[0].MissionName)
+
+	// The stale protobuf directory must have been removed by the replacement.
+	_, err = os.Stat(staleChunk)
+	assert.True(t, os.IsNotExist(err), "stale protobuf chunk must be removed on replace")
+}
+
+// TestIntegration_FailedReuploadPreservesExisting verifies that a re-upload
+// which fails (here: the multipart "file" part is omitted) does NOT destroy the
+// existing recording. Replacement must not delete the old row/files until the
+// new upload is safely written.
+func TestIntegration_FailedReuploadPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	dataDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	repo, err := NewRepoOperation(dbPath)
+	require.NoError(t, err)
+	defer repo.db.Close()
+
+	hdlr := &Handler{
+		repoOperation: repo,
+		setting:       Setting{Data: dataDir, Secret: "test-secret"},
+	}
+
+	const filename = "keep_me"
+
+	// First, a valid upload that succeeds.
+	require.Equal(t, http.StatusOK, uploadJSONRecording(t, hdlr, filename, "Original").Code)
+	jsonGzPath := filepath.Join(dataDir, filename+".json.gz")
+	require.FileExists(t, jsonGzPath)
+
+	// Now re-upload the SAME filename but omit the "file" part → must fail.
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	writer.WriteField("secret", "test-secret")
+	writer.WriteField("filename", filename)
+	writer.WriteField("worldName", "altis")
+	writer.WriteField("missionName", "Botched")
+	writer.WriteField("missionDuration", "300")
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/add", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	hdlr.StoreOperation(rec, req)
+	require.NotEqual(t, http.StatusOK, rec.Code, "upload without a file part must fail")
+
+	// The original recording must still exist — both the DB row and its file.
+	ctx := context.Background()
+	ops, err := repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "original recording must survive a botched re-upload")
+	assert.Equal(t, "Original", ops[0].MissionName)
+	assert.FileExists(t, jsonGzPath, "original data file must survive a botched re-upload")
+}
+
 // TestIntegration_UploadAndServeRawJSON tests uploading a raw (non-gzipped) JSON file.
 // StoreOperation detects the missing gzip header and compresses it before saving as .json.gz.
 // GetData then serves it with Content-Encoding: gzip and the browser can decompress it.

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -483,7 +483,7 @@ func TestIntegration_UploadSameFilenameReplaces(t *testing.T) {
 
 	repo, err := NewRepoOperation(dbPath)
 	require.NoError(t, err)
-	defer repo.db.Close()
+	defer func() { assert.NoError(t, repo.db.Close()) }()
 
 	hdlr := &Handler{
 		repoOperation: repo,
@@ -528,7 +528,7 @@ func TestIntegration_FailedReuploadPreservesExisting(t *testing.T) {
 
 	repo, err := NewRepoOperation(dbPath)
 	require.NoError(t, err)
-	defer repo.db.Close()
+	defer func() { assert.NoError(t, repo.db.Close()) }()
 
 	hdlr := &Handler{
 		repoOperation: repo,
@@ -565,6 +565,38 @@ func TestIntegration_FailedReuploadPreservesExisting(t *testing.T) {
 	require.Len(t, ops, 1, "original recording must survive a botched re-upload")
 	assert.Equal(t, "Original", ops[0].MissionName)
 	assert.FileExists(t, jsonGzPath, "original data file must survive a botched re-upload")
+}
+
+// TestIntegration_UploadRejectsUnsafeFilename verifies that a filename which
+// would resolve to the data directory itself (e.g. empty or ".") is rejected,
+// rather than letting the stale-directory cleanup os.RemoveAll the whole data
+// dir. A marker file in the data dir must survive a rejected upload.
+func TestIntegration_UploadRejectsUnsafeFilename(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "/"} {
+		t.Run("name="+name, func(t *testing.T) {
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "test.db")
+			dataDir := filepath.Join(dir, "data")
+			require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+			repo, err := NewRepoOperation(dbPath)
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, repo.db.Close()) }()
+
+			hdlr := &Handler{
+				repoOperation: repo,
+				setting:       Setting{Data: dataDir, Secret: "test-secret"},
+			}
+
+			// A pre-existing file in the data directory that must not be wiped.
+			canary := filepath.Join(dataDir, "canary.txt")
+			require.NoError(t, os.WriteFile(canary, []byte("keep"), 0644))
+
+			rec := uploadJSONRecording(t, hdlr, name, "Bad Name")
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.FileExists(t, canary, "data directory must survive a rejected upload")
+		})
+	}
 }
 
 // TestIntegration_UploadAndServeRawJSON tests uploading a raw (non-gzipped) JSON file.

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -567,6 +567,36 @@ func TestIntegration_FailedReuploadPreservesExisting(t *testing.T) {
 	assert.FileExists(t, jsonGzPath, "original data file must survive a botched re-upload")
 }
 
+// TestIntegration_UploadWriteFailureLeavesNoRow verifies that when the upload
+// file cannot be written (here: a read-only data directory), the request fails
+// and no operation row is created — the file is written before any DB mutation.
+func TestIntegration_UploadWriteFailureLeavesNoRow(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	repo, err := NewRepoOperation(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, repo.db.Close()) }()
+
+	hdlr := &Handler{
+		repoOperation: repo,
+		setting:       Setting{Data: dataDir, Secret: "test-secret"},
+	}
+
+	// Make the data directory read-only so the temp file cannot be created.
+	require.NoError(t, os.Chmod(dataDir, 0555))
+	defer func() { assert.NoError(t, os.Chmod(dataDir, 0755)) }()
+
+	rec := uploadJSONRecording(t, hdlr, "write_fail", "Write Fail")
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	ctx := context.Background()
+	ops, err := repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+	assert.Empty(t, ops, "a failed write must not create a DB row")
+}
+
 // TestIntegration_UploadRejectsUnsafeFilename verifies that a filename which
 // would resolve to the data directory itself (e.g. empty or ".") is rejected,
 // rather than letting the stale-directory cleanup os.RemoveAll the whole data

--- a/internal/server/operation.go
+++ b/internal/server/operation.go
@@ -281,6 +281,17 @@ func (r *RepoOperation) migration() (err error) {
 	return nil
 }
 
+// isInvalidStorageName reports whether name is unsafe to use as a recording's
+// on-disk storage key. Names like "", ".", ".." or any containing a path
+// separator make filepath.Join(dataDir, name) resolve to the data directory
+// itself or its parent — catastrophic for os.RemoveAll. Such names must be
+// rejected before any file operation keyed on the filename.
+func isInvalidStorageName(name string) bool {
+	return strings.TrimSpace(name) == "" ||
+		name == "." || name == ".." ||
+		strings.ContainsAny(name, `/\`)
+}
+
 // decodeFilename returns the URL-decoded form of name if it contains percent
 // escapes that decode to a different string; otherwise it returns name
 // unchanged. It is used both by the upload handler (to sanitize incoming
@@ -517,6 +528,13 @@ func (r *RepoOperation) StoreReplacingByFilename(ctx context.Context, operation 
 	}
 	defer tx.Rollback()
 
+	// Drop the replaced recording's marker blacklist entries too — they are keyed
+	// by operation_id with no cascade, so they would otherwise orphan.
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM marker_blacklist WHERE operation_id IN (SELECT id FROM operations WHERE filename = ?)`,
+		operation.Filename); err != nil {
+		return err
+	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM operations WHERE filename = ?`, operation.Filename); err != nil {
 		return err
 	}

--- a/internal/server/operation.go
+++ b/internal/server/operation.go
@@ -261,14 +261,10 @@ func (r *RepoOperation) migration() (err error) {
 	}
 
 	if version < 13 {
-		// The filename is the on-disk storage key (`<filename>.json.gz` and the
-		// `<filename>/` protobuf directory), but historically nothing enforced
-		// its uniqueness. Duplicate rows therefore shared — and corrupted — the
-		// same files: uploads overwrote them, conversions merged into them, and
-		// deleting one row removed files still referenced by its twin. Drop the
-		// older duplicate(s), keeping the newest row per filename (they all point
-		// at the same shared files, so no on-disk data is lost), clean up any
-		// now-orphaned blacklist entries, then enforce uniqueness going forward.
+		// filename is the on-disk storage key but was never unique; duplicate
+		// rows shared and corrupted each other's files. Keep the newest row per
+		// filename (duplicates point at the same files, so nothing is lost), drop
+		// orphaned blacklist rows, then enforce uniqueness from here on.
 		if err = r.runMigration(13,
 			`DELETE FROM operations WHERE id NOT IN (SELECT MAX(id) FROM operations GROUP BY filename)`,
 			`DELETE FROM marker_blacklist WHERE operation_id NOT IN (SELECT id FROM operations)`,

--- a/internal/server/operation.go
+++ b/internal/server/operation.go
@@ -260,6 +260,24 @@ func (r *RepoOperation) migration() (err error) {
 		}
 	}
 
+	if version < 13 {
+		// The filename is the on-disk storage key (`<filename>.json.gz` and the
+		// `<filename>/` protobuf directory), but historically nothing enforced
+		// its uniqueness. Duplicate rows therefore shared — and corrupted — the
+		// same files: uploads overwrote them, conversions merged into them, and
+		// deleting one row removed files still referenced by its twin. Drop the
+		// older duplicate(s), keeping the newest row per filename (they all point
+		// at the same shared files, so no on-disk data is lost), clean up any
+		// now-orphaned blacklist entries, then enforce uniqueness going forward.
+		if err = r.runMigration(13,
+			`DELETE FROM operations WHERE id NOT IN (SELECT MAX(id) FROM operations GROUP BY filename)`,
+			`DELETE FROM marker_blacklist WHERE operation_id NOT IN (SELECT id FROM operations)`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_operations_filename ON operations(filename)`,
+		); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -418,7 +436,15 @@ func (r *RepoOperation) GetTypes(ctx context.Context) ([]string, error) {
 	return tags, nil
 }
 
-func (r *RepoOperation) Store(ctx context.Context, operation *Operation) error {
+// execer is satisfied by both *sql.DB and *sql.Tx, letting insertOperation run
+// either standalone or inside a transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// insertOperation inserts a single operation row using the given executor and
+// sets operation.ID to the new auto-generated ID.
+func (r *RepoOperation) insertOperation(ctx context.Context, ex execer, operation *Operation) error {
 	operation.WorldName = strings.ToLower(operation.WorldName)
 	storageFormat := operation.StorageFormat
 	if storageFormat == "" {
@@ -441,7 +467,7 @@ func (r *RepoOperation) Store(ctx context.Context, operation *Operation) error {
 		VALUES
 			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 	`
-	result, err := r.db.ExecContext(
+	result, err := ex.ExecContext(
 		ctx,
 		query,
 		operation.WorldName,
@@ -465,7 +491,6 @@ func (r *RepoOperation) Store(ctx context.Context, operation *Operation) error {
 		return err
 	}
 
-	// Set the auto-generated ID on the operation
 	id, err := result.LastInsertId()
 	if err != nil {
 		return err
@@ -473,6 +498,32 @@ func (r *RepoOperation) Store(ctx context.Context, operation *Operation) error {
 	operation.ID = id
 
 	return nil
+}
+
+func (r *RepoOperation) Store(ctx context.Context, operation *Operation) error {
+	return r.insertOperation(ctx, r.db, operation)
+}
+
+// StoreReplacingByFilename inserts the operation, atomically removing any
+// existing row with the same filename first. This implements upload "replace"
+// semantics (filename is the unique on-disk storage key) without a window in
+// which a failed insert could leave the previous recording deleted: if the
+// insert fails, the transaction rolls back and the old row is preserved. On
+// success operation.ID is set to the new row's ID.
+func (r *RepoOperation) StoreReplacingByFilename(ctx context.Context, operation *Operation) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM operations WHERE filename = ?`, operation.Filename); err != nil {
+		return err
+	}
+	if err := r.insertOperation(ctx, tx, operation); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (r *RepoOperation) Select(ctx context.Context, filter Filter) ([]Operation, error) {

--- a/internal/server/operation_test.go
+++ b/internal/server/operation_test.go
@@ -86,6 +86,87 @@ func TestMigrationV5NormalizeFilenames(t *testing.T) {
 	assert.True(t, filenames["mission_clean"])
 }
 
+// pre-v13 schema with all columns added by migrations 1-12, used to seed a
+// database that predates the filename uniqueness constraint.
+const preV13Schema = `
+	CREATE TABLE version (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, db INTEGER);
+	CREATE TABLE operations (
+		id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+		world_name TEXT NOT NULL, mission_name TEXT NOT NULL, mission_duration INTEGER NOT NULL,
+		filename TEXT NOT NULL, date TEXT NOT NULL, tag TEXT NOT NULL DEFAULT '',
+		storage_format TEXT DEFAULT 'json', conversion_status TEXT DEFAULT 'completed',
+		schema_version INTEGER DEFAULT 1, chunk_count INTEGER DEFAULT 0,
+		player_count INTEGER DEFAULT 0, kill_count INTEGER DEFAULT 0,
+		side_composition TEXT DEFAULT '{}', player_kill_count INTEGER DEFAULT 0,
+		focus_start INTEGER DEFAULT NULL, focus_end INTEGER DEFAULT NULL
+	);
+	CREATE TABLE marker_blacklist (
+		operation_id INTEGER NOT NULL, player_entity_id INTEGER NOT NULL,
+		PRIMARY KEY (operation_id, player_entity_id)
+	);
+	CREATE TABLE steam_allowlist (steam_id TEXT NOT NULL PRIMARY KEY);
+	INSERT INTO version (db) VALUES (12);
+`
+
+// TestMigrationV13DedupeFilenames verifies that migration 13 removes
+// duplicate-filename rows (keeping the newest) and enforces uniqueness, so
+// installs that already accumulated duplicates (the root cause of the
+// shared-file corruption bug) are repaired and prevented going forward.
+func TestMigrationV13DedupeFilenames(t *testing.T) {
+	dir := t.TempDir()
+	pathDB := filepath.Join(dir, "test.db")
+
+	db, err := sql.Open("sqlite3", pathDB)
+	require.NoError(t, err)
+	_, err = db.Exec(preV13Schema)
+	require.NoError(t, err)
+	// Two rows sharing a filename (the bug), plus a unique one.
+	_, err = db.Exec(`
+		INSERT INTO operations (id, world_name, mission_name, mission_duration, filename, date)
+			VALUES (1, 'altis', 'Old', 3600, 'dup_mission', '2026-01-01');
+		INSERT INTO operations (id, world_name, mission_name, mission_duration, filename, date)
+			VALUES (2, 'altis', 'New', 3600, 'dup_mission', '2026-01-02');
+		INSERT INTO operations (id, world_name, mission_name, mission_duration, filename, date)
+			VALUES (3, 'altis', 'Solo', 3600, 'solo_mission', '2026-01-03');
+		INSERT INTO marker_blacklist (operation_id, player_entity_id) VALUES (1, 42);
+		INSERT INTO marker_blacklist (operation_id, player_entity_id) VALUES (2, 99);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Run migrations (including v13).
+	repo, err := NewRepoOperation(pathDB)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, repo.db.Close()) }()
+
+	ctx := context.Background()
+	ops, err := repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+
+	// One row per filename; the newest (id=2, "New") survives the dedupe.
+	require.Len(t, ops, 2)
+	byName := map[string]Operation{}
+	for _, op := range ops {
+		byName[op.Filename] = op
+	}
+	require.Contains(t, byName, "dup_mission")
+	assert.Equal(t, "New", byName["dup_mission"].MissionName)
+	assert.EqualValues(t, 2, byName["dup_mission"].ID)
+	require.Contains(t, byName, "solo_mission")
+
+	// Blacklist entries for the dropped row are gone; the survivor's remain.
+	var orphans int
+	require.NoError(t, repo.db.QueryRow(
+		`SELECT COUNT(*) FROM marker_blacklist WHERE operation_id NOT IN (SELECT id FROM operations)`).Scan(&orphans))
+	assert.Equal(t, 0, orphans, "orphaned blacklist entries must be cleaned")
+
+	// Uniqueness is now enforced: a raw insert of an existing filename fails.
+	_, err = repo.db.Exec(
+		`INSERT INTO operations (world_name, mission_name, mission_duration, filename, date)
+			VALUES ('altis', 'Dupe', 3600, 'solo_mission', '2026-01-05')`)
+	require.Error(t, err, "duplicate filename insert must be rejected by unique index")
+}
+
 func TestOperationStorageFormat(t *testing.T) {
 	dir := t.TempDir()
 	pathDB := filepath.Join(dir, "test.db")
@@ -438,7 +519,7 @@ func TestMigrationRerun(t *testing.T) {
 	var version int
 	err = repo2.db.QueryRow("SELECT db FROM version ORDER BY db DESC LIMIT 1").Scan(&version)
 	assert.NoError(t, err)
-	assert.Equal(t, 12, version)
+	assert.Equal(t, 13, version)
 }
 
 func TestMigrationV10NormalizeWorldName(t *testing.T) {
@@ -448,11 +529,12 @@ func TestMigrationV10NormalizeWorldName(t *testing.T) {
 	repo, err := NewRepoOperation(pathDB)
 	require.NoError(t, err)
 
-	// Insert rows with mixed-case world names directly (bypassing Store normalization)
-	for _, wn := range []string{"Altis", "altis", "ENOCH", "enoch", "Cup_Chernarus_A3"} {
+	// Insert rows with mixed-case world names directly (bypassing Store normalization).
+	// Filenames must be distinct (filename is unique as of migration 13).
+	for i, wn := range []string{"Altis", "altis", "ENOCH", "enoch", "Cup_Chernarus_A3"} {
 		_, err = repo.db.Exec(
-			`INSERT INTO operations (world_name, mission_name, mission_duration, filename, date, tag) VALUES (?, 'test', 100, 'f', '2026-01-01', '')`,
-			wn)
+			`INSERT INTO operations (world_name, mission_name, mission_duration, filename, date, tag) VALUES (?, 'test', 100, ?, '2026-01-01', '')`,
+			wn, fmt.Sprintf("f%d", i))
 		require.NoError(t, err)
 	}
 	require.NoError(t, repo.db.Close())
@@ -545,7 +627,7 @@ func TestMigrationV11DecodeFilenames(t *testing.T) {
 	// Version recorded.
 	var version int
 	require.NoError(t, repo2.db.QueryRow(`SELECT MAX(db) FROM version`).Scan(&version))
-	assert.Equal(t, 12, version)
+	assert.Equal(t, 13, version)
 }
 
 func TestDecodeFilename(t *testing.T) {
@@ -850,7 +932,7 @@ func TestMigrationV11_DBCollisionSkipped(t *testing.T) {
 	// Version still bumped.
 	var version int
 	require.NoError(t, repo2.db.QueryRow(`SELECT MAX(db) FROM version`).Scan(&version))
-	assert.Equal(t, 12, version)
+	assert.Equal(t, 13, version)
 }
 
 func TestMigrationV11_FilesystemCollisionSkipped(t *testing.T) {

--- a/internal/server/operation_test.go
+++ b/internal/server/operation_test.go
@@ -1613,3 +1613,42 @@ func TestUnmarshalSideComposition(t *testing.T) {
 		assert.Nil(t, unmarshalSideComposition("not json"))
 	})
 }
+
+func TestStoreReplacingByFilename(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := NewRepoOperation(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, repo.db.Close()) }()
+
+	ctx := context.Background()
+
+	// Existing recording with a blacklist entry.
+	old := &Operation{WorldName: "altis", MissionName: "Old", MissionDuration: 100, Filename: "dup", Date: "2026-01-01"}
+	require.NoError(t, repo.Store(ctx, old))
+	require.NoError(t, repo.AddBlacklist(ctx, old.ID, 7))
+
+	// Replace it.
+	fresh := &Operation{WorldName: "altis", MissionName: "New", MissionDuration: 200, Filename: "dup", Date: "2026-01-02"}
+	require.NoError(t, repo.StoreReplacingByFilename(ctx, fresh))
+
+	// Exactly one row for the filename, and it is the new one with a new ID.
+	ops, err := repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "New", ops[0].MissionName)
+	assert.NotEqual(t, old.ID, fresh.ID)
+	assert.Equal(t, fresh.ID, ops[0].ID)
+
+	// The replaced recording's blacklist entries were cascaded away.
+	var orphans int
+	require.NoError(t, repo.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM marker_blacklist WHERE operation_id = ?`, old.ID).Scan(&orphans))
+	assert.Equal(t, 0, orphans)
+
+	// Replacing a never-before-seen filename is just an insert.
+	other := &Operation{WorldName: "altis", MissionName: "Solo", MissionDuration: 50, Filename: "solo", Date: "2026-01-03"}
+	require.NoError(t, repo.StoreReplacingByFilename(ctx, other))
+	ops, err = repo.Select(ctx, Filter{Older: "2099-12-31", Newer: "2000-01-01"})
+	require.NoError(t, err)
+	assert.Len(t, ops, 2)
+}

--- a/internal/storage/streaming_converter.go
+++ b/internal/storage/streaming_converter.go
@@ -39,6 +39,16 @@ func (sc *Converter) Convert(ctx context.Context, jsonPath, outputPath string) e
 	}
 	defer reader.Close()
 
+	// Remove any output from a previous conversion before recreating the
+	// directory. Otherwise a re-conversion (e.g. a re-uploaded recording that
+	// reuses a filename, or a retried failed conversion) merges new chunks into
+	// the stale directory, leaving orphaned high-index chunks that corrupt
+	// playback. outputPath is the `<filename>/` directory, distinct from the
+	// `<filename>.json.gz` source, so the input is never touched.
+	if err := os.RemoveAll(outputPath); err != nil {
+		return fmt.Errorf("clean output directory: %w", err)
+	}
+
 	// Create output directory
 	if err := os.MkdirAll(outputPath, 0755); err != nil {
 		return fmt.Errorf("create output directory: %w", err)

--- a/internal/storage/streaming_converter_test.go
+++ b/internal/storage/streaming_converter_test.go
@@ -142,6 +142,52 @@ func TestConverter_Convert(t *testing.T) {
 	assert.Equal(t, uint32(5), chunk1.FrameCount)
 }
 
+// TestConverter_CleansStaleOutput verifies that converting into a directory
+// that already contains output from a previous conversion does not leave stale
+// files behind. Without this, re-converting (e.g. a re-uploaded recording that
+// reuses a filename) merges new chunks into an old directory, leaving orphaned
+// high-index chunks that corrupt playback.
+func TestConverter_CleansStaleOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "test.json")
+	outputPath := filepath.Join(tmpDir, "output")
+
+	testData := map[string]interface{}{
+		"worldName":    "Altis",
+		"missionName":  "Stale Test",
+		"endFrame":     2,
+		"captureDelay": 1.0,
+		"entities": []interface{}{
+			map[string]interface{}{
+				"id": 0, "type": "unit", "name": "P", "side": "WEST",
+				"startFrameNum": 0, "isPlayer": 1.0,
+				"positions": []interface{}{
+					[]interface{}{[]interface{}{100.0, 200.0, 0.0}, 0.0, 1.0, 1.0, "P", 1.0},
+					[]interface{}{[]interface{}{101.0, 201.0, 0.0}, 0.0, 1.0, 1.0, "P", 1.0},
+					[]interface{}{[]interface{}{102.0, 202.0, 0.0}, 0.0, 1.0, 1.0, "P", 1.0},
+				},
+			},
+		},
+		"events":  []interface{}{},
+		"Markers": []interface{}{},
+		"times":   []interface{}{},
+	}
+	jsonData, err := json.Marshal(testData)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(inputPath, jsonData, 0644))
+
+	// Pre-seed the output directory with a stale chunk from a "previous" run.
+	require.NoError(t, os.MkdirAll(filepath.Join(outputPath, "chunks"), 0755))
+	staleChunk := filepath.Join(outputPath, "chunks", "0099.pb")
+	require.NoError(t, os.WriteFile(staleChunk, []byte("stale"), 0644))
+
+	converter := NewConverter(10)
+	require.NoError(t, converter.Convert(context.Background(), inputPath, outputPath))
+
+	_, err = os.Stat(staleChunk)
+	assert.True(t, os.IsNotExist(err), "stale chunk from previous conversion must be removed")
+}
+
 func TestConverter_VehicleCrew(t *testing.T) {
 	tmpDir := t.TempDir()
 	inputPath := filepath.Join(tmpDir, "test.json")


### PR DESCRIPTION
## Problem

Reported by a community admin: after re-uploading a recording (notably when toggling the conversion setting), recordings showed **"failed to load recording data"** on Play. Deleting and re-uploading with the *same* filename didn't fix it — but uploading under a *different* filename did.

## Root cause

The `filename` is the on-disk storage key (`<filename>.json.gz` and the `<filename>/` protobuf directory), but **nothing enforced its uniqueness**. Both affected databases supplied by the reporter contained duplicate-filename rows. Once two rows share a filename, every file operation collides destructively:

- **Delete** removed `<filename>.json.gz` + `RemoveAll(<filename>/)` by filename → destroyed files still referenced by the duplicate row (the "delete leaves recordings in a messed-up state" issue, and why delete+reupload didn't help).
- **Upload** truncated the existing `.json.gz`; **conversion** (`MkdirAll`, no clean) merged new chunks into the old directory.
- A **different filename worked** because it got a fresh, uncontended directory.

The conversion *setting* was a red herring — re-uploading the same files is what minted the duplicate rows.

## Changes

- **Migration v13** — dedupes existing duplicate-filename rows (keeps newest, cleans orphaned `marker_blacklist`), then adds a `UNIQUE` index on `filename`. A naive index would have aborted the migration on already-affected DBs and blocked startup; the dedupe runs first. Verified to boot + dedupe against the reporter's real `data.db` (20→19) and `data.db2` (427→426).
- **Upload replace semantics** — re-uploading an existing filename atomically replaces the old recording. The new file is written **before** any old state is mutated, and the DB row swap runs in a **transaction**, so a malformed or failed upload can never destroy the recording it would replace.
- **Converter cleans its output dir** before writing, so a re-conversion never merges into a stale chunk directory.

## Tests

New tests (written failing-first):
- `TestMigrationV13DedupeFilenames` — dedupe + uniqueness enforced.
- `TestIntegration_UploadSameFilenameReplaces` — re-upload replaces, no duplicate, stale protobuf removed.
- `TestIntegration_FailedReuploadPreservesExisting` — a botched re-upload (missing file part) leaves the original intact.
- `TestConverter_CleansStaleOutput` — stale chunk from a prior conversion is removed.

Full suite green; `go build` + `go vet` clean. No frontend changes (it keys off `storageFormat`, unchanged). Reviewed cross-model with Gemini; the flagged delete-then-insert data-loss window is addressed by the transactional replace.