### PR TITLE
feat: add OCAP_TMP to redirect map-processing scratch off /tmp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ Settings loaded via Viper with priority: environment variables → config files 
 
 **Environment variables** (prefix `OCAP_`):
 - `OCAP_LISTEN`, `OCAP_SECRET`, `OCAP_PREFIXURL`
-- `OCAP_DB`, `OCAP_DATA`, `OCAP_MAPS`, `OCAP_MARKERS`, `OCAP_AMMO`, `OCAP_STATIC`
+- `OCAP_DB`, `OCAP_DATA`, `OCAP_MAPS`, `OCAP_MARKERS`, `OCAP_AMMO`, `OCAP_STATIC`, `OCAP_TMP`
+- `OCAP_TMP` redirects scratch space for map uploads/processing (and the gdal/tippecanoe subprocesses) by setting `TMPDIR`/`CPL_TMPDIR`. Unset = system temp. Set it to a path with space when `/tmp` is too small (e.g. Pelican).
 - `OCAP_CUSTOMIZE_WEBSITEURL`, `OCAP_CUSTOMIZE_WEBSITELOGO`
 
 ## Pelican Panel

--- a/egg-ocap2-web.json
+++ b/egg-ocap2-web.json
@@ -132,6 +132,16 @@
             "user_editable": true,
             "rules": ["nullable", "string"],
             "sort": 10
+        },
+        {
+            "name": "Temp Directory",
+            "description": "Scratch directory for processing map uploads (extraction, tiling). Map imports need significant temporary space and the system /tmp is often too small. Keep this on the persistent volume.",
+            "env_variable": "OCAP_TMP",
+            "default_value": "/home/container/tmp",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": ["required", "string"],
+            "sort": 11
         }
     ]
 }

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -169,12 +169,11 @@ func NewSetting() (setting Setting, err error) {
 		return setting, fmt.Errorf("create maps directory: %w", err)
 	}
 
-	// OCAP_TMP redirects all scratch (map upload, extraction, pipeline working
-	// dirs + the gdal/tippecanoe subprocesses they spawn) off the system /tmp,
-	// which is often too small (e.g. Pelican containers). os.TempDir() re-reads
-	// TMPDIR per call and both tools honor it; CPL_TMPDIR pins gdal regardless.
-	// Resolve to absolute first: subprocesses run with a different working dir
-	// (runCmdDir sets cmd.Dir), so a relative TMPDIR would resolve wrongly.
+	// One redirect covers every maptool scratch site: Go temp (os.TempDir()
+	// re-reads TMPDIR per call) and gdal/tippecanoe subprocess scratch (they
+	// inherit the env; gdal also honors CPL_TMPDIR). Must be absolute —
+	// subprocesses run in a different cwd (runCmdDir), so a relative TMPDIR
+	// would resolve against the wrong dir.
 	if setting.Tmp != "" {
 		if setting.Tmp, err = filepath.Abs(setting.Tmp); err != nil {
 			return setting, fmt.Errorf("resolve tmp directory: %w", err)

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -23,6 +23,7 @@ type Setting struct {
 	Maps       string     `json:"maps" yaml:"maps"`
 	Data       string     `json:"data" yaml:"data"`
 	Static     string     `json:"static" yaml:"static"`
+	Tmp        string     `json:"tmp" yaml:"tmp"`
 	Logger     bool       `json:"logger" yaml:"logger"`
 	Customize  Customize  `json:"customize" yaml:"customize"`
 	Conversion Conversion `json:"conversion" yaml:"conversion"`
@@ -101,6 +102,7 @@ func NewSetting() (setting Setting, err error) {
 	viper.SetDefault("maps", "maps")
 	viper.SetDefault("data", "data")
 	viper.SetDefault("static", "")
+	viper.SetDefault("tmp", "")
 	viper.SetDefault("logger", false)
 	viper.SetDefault("customize.enabled", false)
 	viper.SetDefault("customize.websiteURL", "")
@@ -165,6 +167,18 @@ func NewSetting() (setting Setting, err error) {
 	}
 	if err = os.MkdirAll(setting.Maps, 0755); err != nil {
 		return setting, fmt.Errorf("create maps directory: %w", err)
+	}
+
+	// OCAP_TMP redirects all scratch (map upload, extraction, pipeline working
+	// dirs + the gdal/tippecanoe subprocesses they spawn) off the system /tmp,
+	// which is often too small (e.g. Pelican containers). os.TempDir() re-reads
+	// TMPDIR per call and both tools honor it; CPL_TMPDIR pins gdal regardless.
+	if setting.Tmp != "" {
+		if err = os.MkdirAll(setting.Tmp, 0755); err != nil {
+			return setting, fmt.Errorf("create tmp directory: %w", err)
+		}
+		os.Setenv("TMPDIR", setting.Tmp)
+		os.Setenv("CPL_TMPDIR", setting.Tmp)
 	}
 
 	if setting.Secret == "" || setting.Secret == "same-secret" {

--- a/internal/server/setting.go
+++ b/internal/server/setting.go
@@ -173,7 +173,12 @@ func NewSetting() (setting Setting, err error) {
 	// dirs + the gdal/tippecanoe subprocesses they spawn) off the system /tmp,
 	// which is often too small (e.g. Pelican containers). os.TempDir() re-reads
 	// TMPDIR per call and both tools honor it; CPL_TMPDIR pins gdal regardless.
+	// Resolve to absolute first: subprocesses run with a different working dir
+	// (runCmdDir sets cmd.Dir), so a relative TMPDIR would resolve wrongly.
 	if setting.Tmp != "" {
+		if setting.Tmp, err = filepath.Abs(setting.Tmp); err != nil {
+			return setting, fmt.Errorf("resolve tmp directory: %w", err)
+		}
 		if err = os.MkdirAll(setting.Tmp, 0755); err != nil {
 			return setting, fmt.Errorf("create tmp directory: %w", err)
 		}

--- a/internal/server/setting_test.go
+++ b/internal/server/setting_test.go
@@ -437,6 +437,42 @@ func restoreEnv(key, val string, had bool) {
 	}
 }
 
+func TestNewSetting_TmpRelative(t *testing.T) {
+	defer viper.Reset()
+
+	oldTmpdir, hadTmpdir := os.LookupEnv("TMPDIR")
+	oldCPL, hadCPL := os.LookupEnv("CPL_TMPDIR")
+	defer func() {
+		restoreEnv("TMPDIR", oldTmpdir, hadTmpdir)
+		restoreEnv("CPL_TMPDIR", oldCPL, hadCPL)
+	}()
+
+	// Run from a temp cwd so a relative OCAP_TMP resolves there (and the created
+	// dir is cleaned up) instead of polluting the package directory.
+	work := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(work))
+	defer os.Chdir(oldWd)
+
+	require.NoError(t, os.WriteFile(filepath.Join(work, "setting.json"), []byte(`{"secret": "base-secret"}`), 0644))
+
+	viper.Reset()
+	viper.AddConfigPath(work)
+
+	os.Setenv("OCAP_TMP", "rel-scratch")
+	defer os.Unsetenv("OCAP_TMP")
+
+	setting, err := NewSetting()
+	require.NoError(t, err)
+
+	assert.True(t, filepath.IsAbs(setting.Tmp), "relative OCAP_TMP should be made absolute, got %q", setting.Tmp)
+	assert.Equal(t, setting.Tmp, os.Getenv("TMPDIR"))
+	info, statErr := os.Stat(setting.Tmp)
+	require.NoError(t, statErr, "resolved tmp directory should exist")
+	assert.True(t, info.IsDir())
+}
+
 func TestSetting_AuthSessionTTL(t *testing.T) {
 	defer viper.Reset()
 

--- a/internal/server/setting_test.go
+++ b/internal/server/setting_test.go
@@ -102,6 +102,7 @@ func TestNewSetting_ConfigFile(t *testing.T) {
 		assert.Equal(t, "maps", setting.Maps)
 		assert.Equal(t, "data", setting.Data)
 		assert.Equal(t, "", setting.Static)
+		assert.Equal(t, "", setting.Tmp)
 		assert.False(t, setting.Logger)
 	})
 
@@ -392,6 +393,48 @@ func TestNewSetting_EnvVars(t *testing.T) {
 		assert.True(t, setting.Conversion.Enabled)
 		assert.Equal(t, uint32(600), setting.Conversion.ChunkSize)
 	})
+}
+
+func TestNewSetting_Tmp(t *testing.T) {
+	defer viper.Reset()
+
+	// NewSetting mutates process-global TMPDIR/CPL_TMPDIR; restore so it does
+	// not leak into other tests (t.TempDir itself honors TMPDIR).
+	oldTmpdir, hadTmpdir := os.LookupEnv("TMPDIR")
+	oldCPL, hadCPL := os.LookupEnv("CPL_TMPDIR")
+	defer func() {
+		restoreEnv("TMPDIR", oldTmpdir, hadTmpdir)
+		restoreEnv("CPL_TMPDIR", oldCPL, hadCPL)
+	}()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "setting.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"secret": "base-secret"}`), 0644))
+
+	viper.Reset()
+	viper.AddConfigPath(dir)
+
+	tmpDir := filepath.Join(t.TempDir(), "scratch")
+	os.Setenv("OCAP_TMP", tmpDir)
+	defer os.Unsetenv("OCAP_TMP")
+
+	setting, err := NewSetting()
+	require.NoError(t, err)
+
+	assert.Equal(t, tmpDir, setting.Tmp)
+	info, statErr := os.Stat(tmpDir)
+	require.NoError(t, statErr, "tmp directory should have been created")
+	assert.True(t, info.IsDir())
+	assert.Equal(t, tmpDir, os.Getenv("TMPDIR"), "TMPDIR should point at OCAP_TMP")
+	assert.Equal(t, tmpDir, os.Getenv("CPL_TMPDIR"), "CPL_TMPDIR should point at OCAP_TMP")
+}
+
+func restoreEnv(key, val string, had bool) {
+	if had {
+		os.Setenv(key, val)
+	} else {
+		os.Unsetenv(key)
+	}
 }
 
 func TestSetting_AuthSessionTTL(t *testing.T) {

--- a/setting.json.example
+++ b/setting.json.example
@@ -5,6 +5,7 @@
 	"db": "data.db",
 	"data": "data",
 	"static": "",
+	"tmp": "",
 	"markers": "assets/markers",
 	"ammo": "assets/ammo",
 	"fonts": "assets/fonts",


### PR DESCRIPTION
## Problem

Map uploads fail on Pelican with `write /tmp/ocap-maptool-upload-*.zip: no space left on device`. The container's `/tmp` is too small for the maptool scratch (ZIP extraction + DEM/contour/tile pipeline intermediates). Recording uploads are unaffected — they don't run the maptool pipeline.

The reported error is just the *first* `/tmp` write; the pipeline working dir (`jobmanager.go`) writes far larger intermediates there too.

## Fix

Add an `OCAP_TMP` setting. When set, `NewSetting()` creates the dir and points `TMPDIR` + `CPL_TMPDIR` at it at startup.

A single redirect covers everything:
- `os.TempDir()` re-reads `$TMPDIR` per call (Unix), and the four maptool temp sites use `os.CreateTemp("")` / `os.MkdirTemp("")` / `os.TempDir()`.
- gdal honors `TMPDIR`/`CPL_TMPDIR`, tippecanoe honors `TMPDIR`, and subprocesses inherit the parent env (`cmd.Env` unset).

So **no changes were needed** in `handler_maptool.go` or `jobmanager.go`.

## Behavior

- **Default unset** = system temp (`/tmp`) — no change for existing standalone installs.
- **Pelican egg** ships an editable, required `OCAP_TMP` defaulting to `/home/container/tmp` (persistent volume); the app auto-creates it.
- Existing Pelican servers can set the `OCAP_TMP` startup variable to `/home/container/tmp` and restart, without re-importing the egg.
- Not covered: Windows (uses `%TMP%`/`%TEMP%`, not `TMPDIR`) — out of scope for the container case.

## Test plan

- [x] `go build ./...`, `go vet ./internal/server/`
- [x] `go test ./internal/server/ ./internal/maptool/` pass
- [x] New `TestNewSetting_Tmp`: `OCAP_TMP` creates the dir and sets `TMPDIR`/`CPL_TMPDIR`; default-unset asserts empty
- [x] JSON validity of `egg-ocap2-web.json` and `setting.json.example`