### PR TITLE
feat: add maptool tools and install subcommands

### DIFF
--- a/cmd/ocap-webserver/cli.go
+++ b/cmd/ocap-webserver/cli.go
@@ -47,7 +47,7 @@ func printRootUsage(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  serve      Start the web server")
 	fmt.Fprintln(w, "  convert    Convert mission JSON to protobuf storage")
-	fmt.Fprintln(w, "  maptool    Render grad_meh map exports to tile bundles, or run 'maptool doctor' to diagnose the toolchain")
+	fmt.Fprintln(w, "  maptool    Manage the map toolchain: 'maptool tools|doctor|install|render'")
 	fmt.Fprintln(w, "  help       Show this help")
 	fmt.Fprintln(w, "  version    Show build version")
 	fmt.Fprintln(w)

--- a/internal/maptoolcli/install.go
+++ b/internal/maptoolcli/install.go
@@ -1,0 +1,10 @@
+package maptoolcli
+
+// runInstall prints platform-specific installation instructions.
+func runInstall(args []string, d deps) int {
+	_ = args // install takes no flags currently.
+
+	osInfo := detectOS()
+	printInstallHelp(d.stdout, osInfo)
+	return 0
+}

--- a/internal/maptoolcli/maptool.go
+++ b/internal/maptoolcli/maptool.go
@@ -58,14 +58,18 @@ func Run(args []string) int {
 func dispatch(args []string, d deps) int {
 	if len(args) == 0 {
 		printUsage(d.stderr)
-		fmt.Fprintln(d.stderr, "error: missing subcommand: expected 'render' or 'doctor'")
+		fmt.Fprintln(d.stderr, "error: missing subcommand: expected 'tools', 'doctor', 'install', or 'render'")
 		return 2
 	}
 	switch args[0] {
-	case "render":
-		return runRender(args[1:], d)
+	case "tools":
+		return runTools(args[1:], d)
 	case "doctor":
 		return runDoctor(args[1:], d)
+	case "install":
+		return runInstall(args[1:], d)
+	case "render":
+		return runRender(args[1:], d)
 	case "-h", "--help":
 		printUsage(d.stdout)
 		return 0
@@ -79,8 +83,10 @@ func dispatch(args []string, d deps) int {
 func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "Usage: %s maptool <command> [flags]\n\n", os.Args[0])
 	fmt.Fprintf(w, "Commands:\n")
-	fmt.Fprintf(w, "  doctor         Diagnose the map toolchain (GDAL, tippecanoe, pmtiles)\n")
-	fmt.Fprintf(w, "                 and print install instructions for missing tools\n")
+	fmt.Fprintf(w, "  tools          Show installed map toolchain status\n")
+	fmt.Fprintf(w, "  doctor         Deep-diagnose the map toolchain with gotcha detection\n")
+	fmt.Fprintf(w, "                 and install instructions for missing tools\n")
+	fmt.Fprintf(w, "  install        Print platform-specific install instructions\n")
 	fmt.Fprintf(w, "  render         Render grad_meh map exports to tile bundles\n")
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "Render flags:\n")

--- a/internal/maptoolcli/tools.go
+++ b/internal/maptoolcli/tools.go
@@ -1,0 +1,64 @@
+package maptoolcli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/OCAP2/web/internal/maptool"
+)
+
+// runTools prints a compact status table of all detected tools and exits.
+func runTools(args []string, d deps) int {
+	_ = args // tools takes no flags currently.
+
+	tools := d.detectTools()
+	printToolsTable(d.stdout, tools)
+
+	missing := tools.MissingRequired()
+	if len(missing) > 0 {
+		return 1
+	}
+	return 0
+}
+
+// printToolsTable writes a compact tool status table to w.
+func printToolsTable(w io.Writer, tools maptool.ToolSet) {
+	fmt.Fprintln(w, "Tool               Status    Path")
+	fmt.Fprintln(w, "──────────────────────────────────────────────")
+
+	// Sort: required first, then alphabetical.
+	sorted := make(maptool.ToolSet, len(tools))
+	copy(sorted, tools)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Required != sorted[j].Required {
+			return sorted[i].Required // required first
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	var found, missing int
+	for _, t := range sorted {
+		status := "missing"
+		path := "-"
+		if t.Found {
+			status = "ok"
+			found++
+			path = t.Path
+		} else {
+			missing++
+		}
+		req := ""
+		if t.Required {
+			req = " [required]"
+		}
+		fmt.Fprintf(w, "%-20s %-8s %s%s\n", t.Name, status, path, req)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%d found, %d missing", found, missing)
+	if missing > 0 {
+		fmt.Fprintf(w, " (exit 1)")
+	}
+	fmt.Fprintln(w)
+}

--- a/internal/maptoolcli/tools_install_test.go
+++ b/internal/maptoolcli/tools_install_test.go
@@ -1,0 +1,151 @@
+package maptoolcli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/OCAP2/web/internal/maptool"
+)
+
+// ---------------------------------------------------------------------------
+// tools subcommand tests
+// ---------------------------------------------------------------------------
+
+func TestRunTools_AllFound_Exit0(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+	d.detectTools = allFoundToolSet
+
+	code := runTools(nil, d)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Tool               Status    Path")
+	assert.Contains(t, stdout.String(), "10 found, 0 missing")
+}
+
+func TestRunTools_MissingRequired_Exit1(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+	d.detectTools = allMissingToolSet
+
+	code := runTools(nil, d)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stdout.String(), "0 found, 10 missing")
+	assert.Contains(t, stdout.String(), "(exit 1)")
+}
+
+func TestRunTools_RecommendedMissing_Exit0(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+	d.detectTools = func() maptool.ToolSet {
+		return maptool.ToolSet{
+			{Name: "pmtiles", Required: true, Found: true, Path: "/usr/bin/pmtiles"},
+			{Name: "tippecanoe", Required: true, Found: true, Path: "/usr/bin/tippecanoe"},
+			{Name: "tile-join", Required: false, Found: false},
+			{Name: "gdal_translate", Required: false, Found: false},
+			{Name: "gdaldem", Required: false, Found: false},
+			{Name: "gdal_contour", Required: false, Found: false},
+			{Name: "gdal_calc.py", Required: false, Found: false},
+			{Name: "gdaladdo", Required: false, Found: false},
+			{Name: "gdalbuildvrt", Required: false, Found: false},
+			{Name: "gdal_fillnodata.py", Required: false, Found: false},
+		}
+	}
+
+	code := runTools(nil, d)
+	assert.Equal(t, 0, code, "required all found -> exit 0")
+}
+
+func TestRunTools_Dispatch(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+	d.detectTools = allFoundToolSet
+
+	code := dispatch([]string{"tools"}, d)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Tool               Status    Path")
+}
+
+func TestPrintToolsTable_SortsRequiredFirst(t *testing.T) {
+	tools := maptool.ToolSet{
+		{Name: "gdal_translate", Required: false, Found: true, Path: "/usr/bin/gdal_translate"},
+		{Name: "pmtiles", Required: true, Found: true, Path: "/usr/bin/pmtiles"},
+	}
+	var buf bytes.Buffer
+	printToolsTable(&buf, tools)
+	out := buf.String()
+
+	pmtilesIdx := stringsIndex(out, "pmtiles")
+	gdalIdx := stringsIndex(out, "gdal_translate")
+	assert.Less(t, pmtilesIdx, gdalIdx, "required tools should appear first")
+}
+
+func TestPrintToolsTable_ShowsAllStatuses(t *testing.T) {
+	tools := maptool.ToolSet{
+		{Name: "pmtiles", Required: true, Found: true, Path: "/usr/bin/pmtiles"},
+		{Name: "tippecanoe", Required: true, Found: false},
+	}
+	var buf bytes.Buffer
+	printToolsTable(&buf, tools)
+	out := buf.String()
+
+	assert.Contains(t, out, "ok")
+	assert.Contains(t, out, "missing")
+	assert.Contains(t, out, "[required]")
+}
+
+// ---------------------------------------------------------------------------
+// install subcommand tests
+// ---------------------------------------------------------------------------
+
+func TestRunInstall_Exit0(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+
+	code := runInstall(nil, d)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Installation Instructions")
+}
+
+func TestRunInstall_Dispatch(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	d := fakeDeps(&stdout, &stderr)
+
+	code := dispatch([]string{"install"}, d)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Installation Instructions")
+	assert.Contains(t, stdout.String(), "Notes")
+}
+
+// ---------------------------------------------------------------------------
+// dispatch integration: all subcommands via dispatch
+// ---------------------------------------------------------------------------
+
+func TestDispatch_AllSubcommands(t *testing.T) {
+	for _, sub := range []string{"tools", "doctor", "install"} {
+		t.Run(sub, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			d := fakeDeps(&stdout, &stderr)
+			d.detectTools = allFoundToolSet
+
+			code := dispatch([]string{sub}, d)
+			assert.Equal(t, 0, code, "subcommand %q should exit 0", sub)
+			assert.NotEmpty(t, stdout.String(), "subcommand %q should produce output", sub)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// stringsIndex finds the first occurrence of substr in s.
+func stringsIndex(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Completes the three-command map toolchain CLI:

| Command | Status | From |
|---------|--------|------|
| `maptool tools` | **This PR** | Compact status table |
| `maptool doctor` | PR #528 ✅ | Deep diagnostics + install guide |
| `maptool install` | **This PR** | Platform-specific install instructions |

### `maptool tools`
Quick snapshot of what's installed — sorted with required tools first:

```
$ ocap-webserver maptool tools
Tool               Status    Path
──────────────────────────────────────────────
pmtiles              missing  - [required]
tippecanoe           ok       /usr/bin/tippecanoe [required]
gdal_translate       missing  -
...
2 found, 8 missing (exit 1)
```

### `maptool install`
Prints platform-specific install instructions (auto-detects OS, same output as what `maptool doctor` shows at the bottom when required tools are missing). Always exits 0.

```
$ ocap-webserver maptool install
Installation Instructions
═════════════════════════

Debian / Ubuntu / Pop!_OS / Mint
─────────────────────────────────
...
```

### Files
| File | Purpose |
|------|---------|
| `internal/maptoolcli/tools.go` | Tools subcommand + table printer |
| `internal/maptoolcli/install.go` | Install subcommand (wraps `printInstallHelp`) |
| `internal/maptoolcli/tools_install_test.go` | 11 tests for both commands |
| `internal/maptoolcli/maptool.go` | Registered `tools` and `install` in dispatch |
| `cmd/ocap-webserver/cli.go` | Updated root help