### PR TITLE
fix: hide empty/AI-crewed vehicle labels in 'Players Only' mode

### DIFF
--- a/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
+++ b/ui/src/renderers/leaflet/__tests__/entityCanvasLayer.test.ts
@@ -942,7 +942,7 @@ describe("EntityCanvasLayer — render paths", () => {
     expect(texts).not.toContain("AI Unit");
   });
 
-  it("shows AI vehicle type labels in 'players' mode", () => {
+  it("hides AI-only vehicle type labels in 'players' mode", () => {
     (layer as any).config.nameDisplayMode = () => "players";
     layer.addEntity(1, {
       ...DEFAULT_OPTS,
@@ -958,8 +958,22 @@ describe("EntityCanvasLayer — render paths", () => {
     });
     render();
     const texts = mockCtx.fillText.mock.calls.map((c: any[]) => c[0]);
-    expect(texts).toContain("T-72 (3)");
+    expect(texts).not.toContain("T-72 (3)");
     expect(texts).not.toContain("AI Rifleman");
+  });
+
+  it("shows player-crewed vehicle labels in 'players' mode", () => {
+    (layer as any).config.nameDisplayMode = () => "players";
+    layer.addEntity(1, {
+      ...DEFAULT_OPTS,
+      isPlayer: false,
+      name: "T-72",
+      crew: { count: 2, names: ["Driver", "Gunner"] },
+    });
+    render();
+    const texts = mockCtx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(texts).toContain("Driver");
+    expect(texts).toContain("Gunner");
   });
 
   it("hides AI vehicle type labels when nameMode is 'none'", () => {

--- a/ui/src/renderers/leaflet/entityCanvasLayer.ts
+++ b/ui/src/renderers/leaflet/entityCanvasLayer.ts
@@ -879,11 +879,12 @@ export class EntityCanvasLayer {
       // Vehicle types stay visible in "players" mode so AI vehicles can still be
       // identified without showing every AI infantry name.
       const isVehicle = e.crew !== undefined;
+      const crewHasPlayer = isVehicle && e.crew!.names.length > 0;
       if (
         !hideLabels &&
         nameMode !== "none" &&
         !e.isInVehicle &&
-        (nameMode === "all" || e.isPlayer || isVehicle)
+        (nameMode === "all" || e.isPlayer || (isVehicle && crewHasPlayer))
       ) {
         const [, ih] = e.iconSize;
         const crew = e.crew;

--- a/ui/src/renderers/leaflet/leafletRenderer.ts
+++ b/ui/src/renderers/leaflet/leafletRenderer.ts
@@ -49,6 +49,8 @@ interface InternalMarkerHandle {
   isPlayer: boolean;
   isInVehicle: boolean;
   isVehicle: boolean;
+  /** True when this vehicle has at least one player aboard (used for "players only" labels). */
+  crewHasPlayer: boolean;
 }
 
 interface InternalBriefingHandle {
@@ -794,6 +796,7 @@ export class LeafletRenderer implements MapRenderer {
       isPlayer: opts.isPlayer,
       isInVehicle: false,
       isVehicle: opts.crew !== undefined,
+      crewHasPlayer: !!opts.crew && opts.crew.names.length > 0,
     };
     (marker as any)._ocapInternal = internal;
     return wrapMarker(internal);
@@ -807,6 +810,7 @@ export class LeafletRenderer implements MapRenderer {
     internal.isPlayer = state.isPlayer;
     internal.isInVehicle = state.isInVehicle;
     internal.isVehicle = state.crew !== undefined;
+    internal.crewHasPlayer = !!state.crew && state.crew.names.length > 0;
 
     // Update position
     const latlng = this.armaToLatLng(state.position);
@@ -852,7 +856,7 @@ export class LeafletRenderer implements MapRenderer {
         } else if (
           this._nameDisplayMode() === "players" &&
           !state.isPlayer &&
-          !internal.isVehicle
+          !internal.crewHasPlayer
         ) {
           display = "none";
         }
@@ -1275,7 +1279,7 @@ export class LeafletRenderer implements MapRenderer {
         this._nameDisplayMode() === "players" &&
         internal &&
         !internal.isPlayer &&
-        !internal.isVehicle
+        !internal.crewHasPlayer
       ) {
         display = "none";
       }


### PR DESCRIPTION
## Summary

Addresses [OCAP2/OCAP#96](https://github.com/OCAP2/OCAP/issues/96).

When **Unit labels** is set to **"Players Only"**, vehicle names still showed even if the vehicle was empty or crewed only by AI. This PR makes `"Players Only"` hide empty/AI-only vehicle labels, showing a vehicle's name only when it actually has a player aboard (i.e. `crew.names` is non-empty).

## Changes

- `ui/src/renderers/leaflet/leafletRenderer.ts` (DOM renderer) — track `crewHasPlayer` per entity; in `"players"` mode, hide the popup unless the entity is a player or a vehicle with player crew (both in `updateEntityMarker` and `refreshPopupVisibility`).
- `ui/src/renderers/leaflet/entityCanvasLayer.ts` (default canvas renderer) — in `"players"` mode only draw a vehicle label when it has player crew.
- Tests: `entityCanvasLayer.test.ts` — AI-only vehicle now hidden in `"players"` mode; added a case confirming a player-crewed vehicle still shows its crew labels.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 1624 tests pass (75 files)
- eslint clean
- `vite build` succeeds